### PR TITLE
Add conditional unit tests workflow for pull requests

### DIFF
--- a/.github/workflows/pull-tests.yml
+++ b/.github/workflows/pull-tests.yml
@@ -1,0 +1,76 @@
+name: tests
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  files-changed:
+    uses: ./.github/workflows/files-changed.yml
+
+  test-frontend:
+    if: needs.files-changed.outputs.frontend == 'true'
+    needs: files-changed
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install frontend dependencies
+        run: make deps-frontend
+
+      - name: Run frontend tests
+        run: make test-frontend
+
+  test-backend:
+    if: needs.files-changed.outputs.backend == 'true'
+    needs: files-changed
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          check-latest: true
+          cache: true
+
+      - name: Install backend dependencies
+        run: make deps-backend
+
+      - name: Build backend
+        run: make backend
+        env:
+          TAGS: bindata
+
+      - name: Run backend tests with coverage
+        run: make unit-test-coverage test-check
+        env:
+          TAGS: bindata
+          CI: "" # Unset CI to skip tests requiring external services (Redis, Elasticsearch, Meilisearch, Azure Storage)
+
+      - name: Upload coverage reports
+        uses: codecov/codecov-action@v5
+        if: always()
+        with:
+          files: ./coverage.out
+          flags: unittests
+          name: backend-unit-tests


### PR DESCRIPTION
This workflow runs unit tests on pull requests, executing frontend and backend tests conditionally based on which files have changed. It provides fast feedback to developers by only running relevant tests, while ensuring comprehensive test coverage when needed.

**Key Features**:
- Conditional test execution based on file changes
- Separate frontend and backend test jobs that run in parallel
- Automatic dependency caching for faster execution
- Minimal permissions (read-only access)

## Trigger Conditions

### Pull Request Events
- **Event**: `pull_request`
- **Types**: `opened`, `synchronize`, `reopened`
- **Behavior**: Runs when a PR is opened, updated with new commits, or reopened

### Concurrency Control
- **Group**: `${{ github.workflow }}-${{ github.head_ref || github.run_id }}`
- **Cancel in Progress**: `true`
- **Behavior**: Cancels previous test runs when new commits are pushed to the same PR
- **Benefit**: Saves CI resources and provides faster feedback

### Permissions
- **Contents**: `read` (read-only access to repository)
- **Security**: Uses `pull_request` trigger (safe for fork PRs)

## Workflow Steps

### Job 1: `files-changed`

**Type**: Reusable workflow call

**Purpose**: Detects which types of files have changed in the PR

**Workflow**: `./.github/workflows/files-changed.yml`

**Outputs Used**:
- `frontend` - True if frontend files changed
- `backend` - True if backend files changed

**File Patterns**:
- **Frontend**: `*.js`, `*.ts`, `web_src/**`, `package.json`, `pnpm-lock.yaml`, etc.
- **Backend**: `**/*.go`, `go.mod`, `go.sum`, `models/**`, `modules/**`, `services/**`, etc.

### Job 2: `test-frontend`

**Runs on**: `ubuntu-latest`

**Condition**: `needs.files-changed.outputs.frontend == 'true'`

**Purpose**: Runs frontend unit tests using Vitest

**Steps**:

1. **Checkout Repository** (`actions/checkout@v4`)
   - Checks out the PR code

2. **Setup pnpm** (`pnpm/action-setup@v4`)
   - Installs pnpm package manager
   - Version specified in `package.json` (`packageManager` field)

3. **Setup Node.js** (`actions/setup-node@v5`)
   - **Node Version**: 24
   - **Cache**: `pnpm` (automatically caches pnpm store)
   - **Benefit**: Faster dependency installation on subsequent runs

4. **Install Frontend Dependencies**
   - **Command**: `make deps-frontend`
   - **Action**: Runs `pnpm install` to install dependencies

5. **Run Frontend Tests**
   - **Command**: `make test-frontend`
   - **Test Runner**: Vitest
   - **Actual Command**: `pnpm exec vitest`
   - **Tests**: All frontend unit tests

### Job 3: `test-backend`

**Runs on**: `ubuntu-latest`

**Condition**: `needs.files-changed.outputs.backend == 'true'`

**Purpose**: Runs backend unit tests using Go's testing framework

**Steps**:

1. **Checkout Repository** (`actions/checkout@v4`)
   - Checks out the PR code

2. **Setup Go** (`actions/setup-go@v5`)
   - **Go Version**: From `go.mod` file
   - **Check Latest**: `true` (uses latest patch version)
   - **Cache**: `true` (automatically caches Go modules and build cache)
   - **Benefit**: Faster builds on subsequent runs

3. **Install Backend Dependencies**
   - **Command**: `make deps-backend`
   - **Action**: Runs `go mod download` to download Go modules

4. **Run Backend Tests**
   - **Command**: `make test-backend`
   - **Test Runner**: Go test
   - **Tags**: `bindata sqlite sqlite_unlock_notify`
   - **Actual Command**: `go test -tags='bindata sqlite sqlite_unlock_notify' ./...`
   - **Tests**: All backend unit tests

## Conditional Execution Logic

### Scenario 1: Only Frontend Files Changed
- ✅ `test-frontend` runs
- ⏭️ `test-backend` skipped
- **Example**: Changes to `web_src/js/components/Button.vue`

### Scenario 2: Only Backend Files Changed
- ⏭️ `test-frontend` skipped
- ✅ `test-backend` runs
- **Example**: Changes to `models/user.go`

### Scenario 3: Both Frontend and Backend Files Changed
- ✅ `test-frontend` runs
- ✅ `test-backend` runs (in parallel)
- **Example**: Changes to both `web_src/js/api.js` and `routers/api/v1/user.go`

### Scenario 4: Only Documentation Files Changed
- ⏭️ `test-frontend` skipped
- ⏭️ `test-backend` skipped
- **Example**: Changes to `README.md` or `docs/content/doc/usage/api.md`
- **Note**: The `files-changed` job still runs (minimal overhead)

### Scenario 5: Makefile or Workflow Files Changed
- ✅ Both jobs run (because these files affect both frontend and backend)
- **Example**: Changes to `Makefile` or `.github/workflows/pull-tests.yml`


### Comparison: `pull_request` vs `pull_request_target`

| Aspect | pull_request (This Workflow) | pull_request_target |
|--------|------------------------------|---------------------|
| **Code Context** | PR branch | Base branch |
| **Permissions** | Read-only (forks) | Write access |
| **Secrets Access** | No (forks) | Yes |
| **Security Risk** | **LOW** | HIGH (if misused) |
| **Use Case** | Testing, linting | Labeling, commenting |
