### PR TITLE
Hide Projects, Packages, and Public Activity links from user profile

### DIFF
--- a/custom/templates/user/overview/header.tmpl
+++ b/custom/templates/user/overview/header.tmpl
@@ -11,6 +11,7 @@
 				<div class="ui small label">{{.RepoCount}}</div>
 			{{end}}
 		</a>
+		{{/* Projects link hidden - not used in Forkana
 		{{if or .ContextUser.IsIndividual .CanReadProjects}}
 		<a href="{{.ContextUser.HomeLink}}/-/projects" class="{{if .PageIsViewProjects}}active {{end}}item">
 			{{svg "octicon-project-symlink"}} {{ctx.Locale.Tr "user.projects"}}
@@ -19,20 +20,25 @@
 			{{end}}
 		</a>
 		{{end}}
+		*/}}
+		{{/* Packages link hidden - not used in Forkana
 		{{if and .IsPackageEnabled (or .ContextUser.IsIndividual .CanReadPackages)}}
 			<a href="{{.ContextUser.HomeLink}}/-/packages" class="{{if .IsPackagesPage}}active {{end}}item">
 				{{svg "octicon-package"}} {{ctx.Locale.Tr "packages.title"}}
 			</a>
 		{{end}}
+		*/}}
 		{{if and .IsRepoIndexerEnabled (or .ContextUser.IsIndividual .CanReadCode)}}
 			<a href="{{.ContextUser.HomeLink}}/-/code" class="{{if .IsCodePage}}active {{end}}item">
 				{{svg "octicon-code"}} {{ctx.Locale.Tr "user.code"}}
 			</a>
 		{{end}}
 		{{if .ContextUser.IsIndividual}}
+			{{/* Public Activity link hidden - not used in Forkana
 			<a class="{{if eq .TabName "activity"}}active {{end}}item" href="{{.ContextUser.HomeLink}}?tab=activity">
 				{{svg "octicon-rss"}} {{ctx.Locale.Tr "user.activity"}}
 			</a>
+			*/}}
 			{{if not .DisableStars}}
 			<a class="{{if eq .TabName "stars"}}active {{end}}item" href="{{.ContextUser.HomeLink}}?tab=stars">
 				{{svg "octicon-star"}} {{ctx.Locale.Tr "user.starred"}}

--- a/templates/user/overview/header.tmpl
+++ b/templates/user/overview/header.tmpl
@@ -11,6 +11,7 @@
 				<div class="ui small label">{{.RepoCount}}</div>
 			{{end}}
 		</a>
+		{{/* Projects link hidden - not used in Forkana
 		{{if or .ContextUser.IsIndividual .CanReadProjects}}
 		<a href="{{.ContextUser.HomeLink}}/-/projects" class="{{if .PageIsViewProjects}}active {{end}}item">
 			{{svg "octicon-project-symlink"}} {{ctx.Locale.Tr "user.projects"}}
@@ -19,20 +20,25 @@
 			{{end}}
 		</a>
 		{{end}}
+		*/}}
+		{{/* Packages link hidden - not used in Forkana
 		{{if and .IsPackageEnabled (or .ContextUser.IsIndividual .CanReadPackages)}}
 			<a href="{{.ContextUser.HomeLink}}/-/packages" class="{{if .IsPackagesPage}}active {{end}}item">
 				{{svg "octicon-package"}} {{ctx.Locale.Tr "packages.title"}}
 			</a>
 		{{end}}
+		*/}}
 		{{if and .IsRepoIndexerEnabled (or .ContextUser.IsIndividual .CanReadCode)}}
 			<a href="{{.ContextUser.HomeLink}}/-/code" class="{{if .IsCodePage}}active {{end}}item">
 				{{svg "octicon-code"}} {{ctx.Locale.Tr "user.code"}}
 			</a>
 		{{end}}
 		{{if .ContextUser.IsIndividual}}
+			{{/* Public Activity link hidden - not used in Forkana
 			<a class="{{if eq .TabName "activity"}}active {{end}}item" href="{{.ContextUser.HomeLink}}?tab=activity">
 				{{svg "octicon-rss"}} {{ctx.Locale.Tr "user.activity"}}
 			</a>
+			*/}}
 			{{if not .DisableStars}}
 			<a class="{{if eq .TabName "stars"}}active {{end}}item" href="{{.ContextUser.HomeLink}}?tab=stars">
 				{{svg "octicon-star"}} {{ctx.Locale.Tr "user.starred"}}


### PR DESCRIPTION
Same reasoning as https://github.com/okTurtles/forkana/pull/107.

This

<img width="1252" height="82" alt="Screenshot 2026-01-17 at 13 32 08" src="https://github.com/user-attachments/assets/34e3db99-ae4a-44c6-8e54-8bd11f278d30" />

brings us closer to

<img width="1116" height="80" alt="Screenshot 2026-01-17 at 13 30 23" src="https://github.com/user-attachments/assets/ece27c90-4b6c-4e0b-9779-f11a065d1d47" />

(The "Starred Repositories" could be converted to "Watched")



<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/okturtles/forkana/pull/108">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
