### PR TITLE
Hide New Migration and New Organization menu items

### DIFF
--- a/custom/templates/base/head_navbar.tmpl
+++ b/custom/templates/base/head_navbar.tmpl
@@ -77,16 +77,20 @@
 					<a class="item" href="{{AppSubUrl}}/repo/create">
 						{{svg "octicon-plus"}} {{ctx.Locale.Tr "new_repo"}}
 					</a>
+					{{/* Migration link hidden - not used in Forkana
 					{{if not .DisableMigrations}}
 						<a class="item" href="{{AppSubUrl}}/repo/migrate">
 							{{svg "octicon-repo-push"}} {{ctx.Locale.Tr "new_migrate"}}
 						</a>
 					{{end}}
+					*/}}
+					{{/* New Organization link hidden - not used in Forkana
 					{{if .SignedUser.CanCreateOrganization}}
 					<a class="item" href="{{AppSubUrl}}/org/create">
 						{{svg "octicon-organization"}} {{ctx.Locale.Tr "new_org"}}
 					</a>
 					{{end}}
+					*/}}
 				</div><!-- end content create new menu -->
 			</div><!-- end dropdown menu create new -->
 

--- a/templates/base/head_navbar.tmpl
+++ b/templates/base/head_navbar.tmpl
@@ -77,16 +77,20 @@
 					<a class="item" href="{{AppSubUrl}}/repo/create">
 						{{svg "octicon-plus"}} {{ctx.Locale.Tr "new_repo"}}
 					</a>
+					{{/* Migration link hidden - not used in Forkana
 					{{if not .DisableMigrations}}
 						<a class="item" href="{{AppSubUrl}}/repo/migrate">
 							{{svg "octicon-repo-push"}} {{ctx.Locale.Tr "new_migrate"}}
 						</a>
 					{{end}}
+					*/}}
+					{{/* New Organization link hidden - not used in Forkana
 					{{if .SignedUser.CanCreateOrganization}}
 					<a class="item" href="{{AppSubUrl}}/org/create">
 						{{svg "octicon-organization"}} {{ctx.Locale.Tr "new_org"}}
 					</a>
 					{{end}}
+					*/}}
 				</div><!-- end content create new menu -->
 			</div><!-- end dropdown menu create new -->
 


### PR DESCRIPTION
On the de-Gitea-ify topic, this PR

gets us from

<img width="296" height="235" alt="Screenshot 2026-01-25 at 08 29 05" src="https://github.com/user-attachments/assets/f1649514-ada0-4234-9898-2d206e71ccbc" />

to

<img width="324" height="131" alt="Screenshot 2026-01-25 at 08 27 58" src="https://github.com/user-attachments/assets/d41eb0d7-09b5-4fdd-9453-bd43d1eb3dc5" />


Same approach as #107, #108, with the note that `[explore] ORGANIZATIONS_PAGE_DISABLED = true`  didn't do anything with regards to the items shown here as well (see comments in #108). I think the `[explore]` means probably that it would hide it from the Explore page (but is apparently hidden in other ways by now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/okturtles/forkana/pull/126">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
