### PR TITLE
Fix #179: Remove remaining unnecessary branch-deletion elements from the UI

### DIFF
--- a/custom/templates/repo/issue/view_content.tmpl
+++ b/custom/templates/repo/issue/view_content.tmpl
@@ -172,13 +172,4 @@
 {{template "repo/issue/view_content/reference_issue_dialog" .}}
 {{template "shared/user/block_user_dialog" .}}
 
-<div class="ui g-modal-confirm delete modal">
-	<div class="header">
-		{{svg "octicon-trash"}}
-		{{ctx.Locale.Tr "repo.branch.delete" .HeadTarget}}
-	</div>
-	<div class="content">
-		<p>{{ctx.Locale.Tr "repo.branch.delete_desc"}}</p>
-	</div>
-	{{template "base/modal_actions_confirm" .}}
-</div>
+

--- a/custom/templates/repo/issue/view_content/pull_merge_box.tmpl
+++ b/custom/templates/repo/issue/view_content/pull_merge_box.tmpl
@@ -246,6 +246,7 @@
 							const defaultSquashMergeMessage = {{.DefaultSquashMergeBody}};
 							const mergeForm = {
 								'baseLink': {{.Issue.Link}},
+								'headBranch': '{{.HeadTarget}}',
 								'textCancel': {{ctx.Locale.Tr "cancel"}},
 
 								'textAutoMergeButtonWhenSucceed': {{ctx.Locale.Tr "repo.pulls.auto_merge_button_when_succeed"}},

--- a/custom/templates/repo/issue/view_content/pull_merge_box.tmpl
+++ b/custom/templates/repo/issue/view_content/pull_merge_box.tmpl
@@ -53,7 +53,6 @@
 							</div>
 						</div>
 						<div class="item-section-right">
-							<button class="delete-button ui button" data-url="{{.DeleteBranchLink}}">{{ctx.Locale.Tr "repo.branch.delete_html"}}</button>
 						</div>
 					</div>
 				{{end}}
@@ -81,9 +80,6 @@
 						{{end}}
 					</div>
 					<div class="item-section-right">
-						{{if and .IsPullBranchDeletable (not .IsPullRequestBroken)}}
-							<button class="delete-button ui button" data-url="{{.DeleteBranchLink}}">{{ctx.Locale.Tr "repo.branch.delete_html"}}</button>
-						{{end}}
 						{{if .CanForkRejectedChanges}}
 							<form class="form-fetch-action" method="post" action="{{.Issue.Link}}/fork_rejected_changes">
 								{{.CsrfTokenHtml}}
@@ -251,7 +247,7 @@
 							const mergeForm = {
 								'baseLink': {{.Issue.Link}},
 								'textCancel': {{ctx.Locale.Tr "cancel"}},
-								'textDeleteBranch': {{ctx.Locale.Tr "repo.branch.delete" .HeadTarget}},
+
 								'textAutoMergeButtonWhenSucceed': {{ctx.Locale.Tr "repo.pulls.auto_merge_button_when_succeed"}},
 								'textAutoMergeWhenSucceed': {{ctx.Locale.Tr "repo.pulls.auto_merge_when_succeed"}},
 								'textAutoMergeCancelSchedule': {{ctx.Locale.Tr "repo.pulls.auto_merge_cancel_schedule"}},

--- a/custom/templates/repo/issue/view_content/pull_merge_box.tmpl
+++ b/custom/templates/repo/issue/view_content/pull_merge_box.tmpl
@@ -239,7 +239,6 @@
 							const defaultSquashMergeMessage = {{.DefaultSquashMergeBody}};
 							const mergeForm = {
 								'baseLink': {{.Issue.Link}},
-								'headBranch': '{{.HeadTarget}}',
 								'textCancel': {{ctx.Locale.Tr "cancel"}},
 								'textAutoMergeButtonWhenSucceed': {{ctx.Locale.Tr "repo.pulls.auto_merge_button_when_succeed"}},
 								'textAutoMergeWhenSucceed': {{ctx.Locale.Tr "repo.pulls.auto_merge_when_succeed"}},

--- a/custom/templates/repo/issue/view_content/pull_merge_box.tmpl
+++ b/custom/templates/repo/issue/view_content/pull_merge_box.tmpl
@@ -252,7 +252,6 @@
 								'allOverridableChecksOk': {{not $notAllOverridableChecksOk}},
 								'emptyCommit': {{.Issue.PullRequest.IsEmpty}},
 								'pullHeadCommitID': {{.PullHeadCommitID}},
-								'isPullBranchDeletable': {{.IsPullBranchDeletable}},
 								'defaultMergeStyle': {{.MergeStyle}},
 								'mergeMessageFieldPlaceHolder': {{ctx.Locale.Tr "repo.editor.commit_message_desc"}},
 								'defaultMergeMessage': defaultMergeMessage,

--- a/custom/templates/repo/issue/view_content/pull_merge_box.tmpl
+++ b/custom/templates/repo/issue/view_content/pull_merge_box.tmpl
@@ -1,6 +1,3 @@
-{{if and .Issue.PullRequest.HasMerged (not .IsPullBranchDeletable)}}
-{{/* Then the merge box will not be displayed because this page already contains enough information */}}
-{{else}}
 {{$mergeColor := "red"}}
 {{- if .Issue.PullRequest.HasMerged}}{{$mergeColor = "purple"}}
 {{- else if .Issue.IsClosed}}{{$mergeColor = "grey"}}
@@ -42,20 +39,16 @@
 		{{$showGeneralMergeForm := false}}
 		<div class="ui attached segment merge-section {{if not $.LatestCommitStatus}}avatar-content-left-arrow{{end}} flex-items-block border-{{$mergeColor}}">
 			{{if .Issue.PullRequest.HasMerged}}
-				{{if .IsPullBranchDeletable}}
-					<div class="item item-section text tw-flex-1">
-						<div class="item-section-left">
-							<h3 class="tw-mb-2">
-								{{ctx.Locale.Tr "repo.pulls.merged_success"}}
-							</h3>
-							<div class="merge-section-info">
-								{{ctx.Locale.Tr "repo.pulls.merged_info_text" (HTMLFormat "<code>%s</code>" .HeadTarget)}}
-							</div>
-						</div>
-						<div class="item-section-right">
+				<div class="item item-section text tw-flex-1">
+					<div class="item-section-left">
+						<h3 class="tw-mb-2">
+							{{ctx.Locale.Tr "repo.pulls.merged_success"}}
+						</h3>
+						<div class="merge-section-info">
+							{{ctx.Locale.Tr "repo.pulls.merged_info_text" (HTMLFormat "<code>%s</code>" .HeadTarget)}}
 						</div>
 					</div>
-				{{end}}
+				</div>
 			{{else if .Issue.IsClosed}}
 				<div class="item item-section text tw-flex-1">
 					<div class="item-section-left">
@@ -248,7 +241,6 @@
 								'baseLink': {{.Issue.Link}},
 								'headBranch': '{{.HeadTarget}}',
 								'textCancel': {{ctx.Locale.Tr "cancel"}},
-
 								'textAutoMergeButtonWhenSucceed': {{ctx.Locale.Tr "repo.pulls.auto_merge_button_when_succeed"}},
 								'textAutoMergeWhenSucceed': {{ctx.Locale.Tr "repo.pulls.auto_merge_when_succeed"}},
 								'textAutoMergeCancelSchedule': {{ctx.Locale.Tr "repo.pulls.auto_merge_cancel_schedule"}},
@@ -391,4 +383,3 @@
 		</div>
 	</div>
 </div>
-{{end}}

--- a/custom/templates/repo/issue/view_title.tmpl
+++ b/custom/templates/repo/issue/view_title.tmpl
@@ -8,6 +8,7 @@
 	data-issue-dependency-search-type="{{$.IssueDependencySearchType}}"
 	data-issue-repo-link="{{$.RepoLink}}"
 	data-issue-repo-id="{{$.Repository.ID}}"
+	{{if .Issue.IsPull}}data-issue-head-branch="{{.HeadTarget}}"{{end}}
 ></div>
 {{if and .Issue.IsPull .Issue.PullRequest.HeadRepo}}
 <div class="pr-repo-header">

--- a/custom/templates/repo/issue/view_title.tmpl
+++ b/custom/templates/repo/issue/view_title.tmpl
@@ -8,7 +8,6 @@
 	data-issue-dependency-search-type="{{$.IssueDependencySearchType}}"
 	data-issue-repo-link="{{$.RepoLink}}"
 	data-issue-repo-id="{{$.Repository.ID}}"
-	{{if .Issue.IsPull}}data-issue-head-branch="{{.HeadTarget}}"{{end}}
 ></div>
 {{if and .Issue.IsPull .Issue.PullRequest.HeadRepo}}
 <div class="pr-repo-header">

--- a/custom/templates/repo/settings/options.tmpl
+++ b/custom/templates/repo/settings/options.tmpl
@@ -1,3 +1,9 @@
+{{/*
+  Forkana custom override of templates/repo/settings/options.tmpl.
+  Change from upstream: removed the "default_delete_branch_after_merge" checkbox
+  (originally ~lines 634-639) because Forkana always auto-deletes branches on merge.
+  When syncing this file with upstream, re-apply that removal.
+*/}}
 {{template "repo/settings/layout_head" (dict "ctxData" . "pageClass" "repository settings options")}}
 	<div class="user-main-content twelve wide column">
 		<h4 class="ui top attached header">

--- a/custom/templates/repo/settings/options.tmpl
+++ b/custom/templates/repo/settings/options.tmpl
@@ -1,0 +1,1110 @@
+{{template "repo/settings/layout_head" (dict "ctxData" . "pageClass" "repository settings options")}}
+	<div class="user-main-content twelve wide column">
+		<h4 class="ui top attached header">
+			{{ctx.Locale.Tr "repo.settings.basic_settings"}}
+		</h4>
+		<div class="ui attached segment">
+			<form class="ui form" action="{{.Link}}" method="post">
+				{{template "base/disable_form_autofill"}}
+				{{.CsrfTokenHtml}}
+				<input type="hidden" name="action" value="update">
+				<div class="required field {{if .Err_RepoName}}error{{end}}">
+					<label>{{ctx.Locale.Tr "repo.repo_name"}}</label>
+					<input name="repo_name" value="{{.Repository.Name}}" data-repo-name="{{.Repository.Name}}" required>
+				</div>
+				<div class="field {{if .Err_Subject}}error{{end}}">
+					<label>{{ctx.Locale.Tr "repo.subject"}}</label>
+					<input name="subject" value="{{.Repository.GetSubject ctx}}" maxlength="255" readonly disabled>
+					<span class="help">{{ctx.Locale.Tr "repo.subject_cannot_be_modified"}}</span>
+				</div>
+				<div class="inline field">
+					<label>{{ctx.Locale.Tr "repo.repo_size"}}</label>
+					<span {{if not (eq .Repository.Size 0)}} data-tooltip-content="{{.Repository.SizeDetailsString}}"{{end}}>{{FileSize .Repository.Size}}</span>
+				</div>
+				<div class="inline field">
+					<label>{{ctx.Locale.Tr "repo.template"}}</label>
+					<div class="ui checkbox">
+						<input name="template" type="checkbox" {{if .Repository.IsTemplate}}checked{{end}}>
+						<label>{{ctx.Locale.Tr "repo.template_helper"}}</label>
+					</div>
+				</div>
+				<div class="field {{if .Err_Description}}error{{end}}">
+					<label for="description">{{ctx.Locale.Tr "repo.repo_desc"}}</label>
+					<textarea id="description" name="description" rows="2" maxlength="2048">{{.Repository.Description}}</textarea>
+				</div>
+				<div class="field {{if .Err_Website}}error{{end}}">
+					<label for="website">{{ctx.Locale.Tr "repo.settings.site"}}</label>
+					<input id="website" name="website" type="url" maxlength="1024" value="{{.Repository.Website}}">
+				</div>
+				<div class="field">
+					<button class="ui primary button">{{ctx.Locale.Tr "repo.settings.update_settings"}}</button>
+				</div>
+			</form>
+
+			<div class="divider"></div>
+			<form class="ui form" action="{{.Link}}/avatar" method="post" enctype="multipart/form-data">
+				{{.CsrfTokenHtml}}
+				<div class="inline field">
+					{{template "shared/avatar_upload_crop" dict "LabelText" (ctx.Locale.Tr "settings.choose_new_avatar")}}
+				</div>
+				<div class="field">
+					<button class="ui primary button">{{ctx.Locale.Tr "settings.update_avatar"}}</button>
+					<button class="ui red button link-action" data-url="{{.Link}}/avatar/delete">{{ctx.Locale.Tr "settings.delete_current_avatar"}}</button>
+				</div>
+			</form>
+		</div>
+
+		{{/* These variables exist to make the logic in the Settings window easier to comprehend and are not used later on. */}}
+		{{$newMirrorsPartiallyEnabled := or (not .DisableNewPullMirrors) (not .DisableNewPushMirrors)}}
+		{{/* .Repository.IsMirror is not always reliable if the repository is not actively acting as a mirror because of errors. */}}
+		{{$showMirrorSettings := and (.Repository.UnitEnabled ctx ctx.Consts.RepoUnitTypeCode) (or $newMirrorsPartiallyEnabled .Repository.IsMirror .PullMirror .PushMirrors)}}
+		{{$newMirrorsEntirelyEnabled := and (not .DisableNewPullMirrors) (not .DisableNewPushMirrors)}}
+		{{$onlyNewPushMirrorsEnabled := and (not .DisableNewPushMirrors) .DisableNewPullMirrors}}
+		{{$onlyNewPullMirrorsEnabled := and .DisableNewPushMirrors (not .DisableNewPullMirrors)}}
+		{{$existingPushMirror := or .Repository.IsMirror .PushMirrors}}
+		{{$modifyBrokenPullMirror := and .Repository.IsMirror (not .PullMirror)}}
+		{{$isWorkingPullMirror := .PullMirror}}
+
+		{{if $showMirrorSettings}}
+			<h4 class="ui top attached header">
+				{{ctx.Locale.Tr "repo.settings.mirror_settings"}}
+			</h4>
+			<div class="ui attached segment">
+				{{if .Repository.IsArchived}}
+					<div class="ui warning message tw-text-center">
+						{{ctx.Locale.Tr "repo.settings.archive.mirrors_unavailable"}}
+					</div>
+				{{else}}
+					{{if $newMirrorsEntirelyEnabled}}
+						{{ctx.Locale.Tr "repo.settings.mirror_settings.docs"}}
+						<a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.com/usage/repo-mirror#pushing-to-a-remote-repository">{{ctx.Locale.Tr "repo.settings.mirror_settings.docs.doc_link_title"}}</a><br><br>
+						{{ctx.Locale.Tr "repo.settings.mirror_settings.docs.pull_mirror_instructions"}}
+						<a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.com/usage/repo-mirror#pulling-from-a-remote-repository">{{ctx.Locale.Tr "repo.settings.mirror_settings.docs.doc_link_pull_section"}}</a><br>
+					{{else if $onlyNewPushMirrorsEnabled}}
+						{{ctx.Locale.Tr "repo.settings.mirror_settings.docs.disabled_pull_mirror.instructions"}}
+						{{ctx.Locale.Tr "repo.settings.mirror_settings.docs.more_information_if_disabled"}}
+						<a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.com/usage/repo-mirror#pulling-from-a-remote-repository">{{ctx.Locale.Tr "repo.settings.mirror_settings.docs.doc_link_title"}}</a><br>
+					{{else if $onlyNewPullMirrorsEnabled}}
+						{{ctx.Locale.Tr "repo.settings.mirror_settings.docs.disabled_push_mirror.instructions"}}
+						{{ctx.Locale.Tr "repo.settings.mirror_settings.docs.disabled_push_mirror.pull_mirror_warning"}}
+						{{ctx.Locale.Tr "repo.settings.mirror_settings.docs.more_information_if_disabled"}}
+						<a target="_blank" rel="noopener noreferrer" href="https://docs.gitea.com/usage/repo-mirror#pulling-from-a-remote-repository">{{ctx.Locale.Tr "repo.settings.mirror_settings.docs.doc_link_title"}}</a><br><br>
+						{{ctx.Locale.Tr "repo.settings.mirror_settings.docs.disabled_push_mirror.info"}}
+						{{if $existingPushMirror}}
+							{{ctx.Locale.Tr "repo.settings.mirror_settings.docs.can_still_use"}}
+						{{end}}
+					{{else}}
+						{{ctx.Locale.Tr "repo.settings.mirror_settings.docs.no_new_mirrors"}} {{ctx.Locale.Tr "repo.settings.mirror_settings.docs.can_still_use"}}<br>
+					{{end}}
+
+					{{if .Repository.IsMirror}}
+					<table class="ui table">
+						<thead>
+							<tr>
+								<th class="tw-w-2/5">{{ctx.Locale.Tr "repo.settings.mirror_settings.mirrored_repository"}}</th>
+								<th>{{ctx.Locale.Tr "repo.settings.mirror_settings.direction"}}</th>
+								<th>{{ctx.Locale.Tr "repo.settings.mirror_settings.last_update"}}</th>
+								<th></th>
+							</tr>
+						</thead>
+						{{if $modifyBrokenPullMirror}}
+							{{/* even if a repo is a pull mirror (IsMirror=true), the PullMirror might still be nil if the mirror migration is broken */}}
+							<tbody>
+								<tr>
+									<td colspan="4">
+										<div class="text red tw-py-4">{{ctx.Locale.Tr "repo.settings.mirror_settings.direction.pull"}}: {{ctx.Locale.Tr "error.occurred"}}</div>
+									</td>
+								</tr>
+							</tbody>
+						{{else if $isWorkingPullMirror}}
+						<tbody>
+							<tr>
+								<td>{{.PullMirror.RemoteAddress}}</td>
+								<td>{{ctx.Locale.Tr "repo.settings.mirror_settings.direction.pull"}}</td>
+								<td>{{DateUtils.FullTime .PullMirror.UpdatedUnix}}</td>
+								<td class="tw-text-right">
+									<form method="post" class="tw-inline-block">
+										{{.CsrfTokenHtml}}
+										<input type="hidden" name="action" value="mirror-sync">
+										<button class="ui primary tiny button inline">{{ctx.Locale.Tr "repo.settings.sync_mirror"}}</button>
+									</form>
+								</td>
+							</tr>
+							<tr>
+								<td colspan="4">
+									<form class="ui form" method="post">
+										{{template "base/disable_form_autofill"}}
+										{{.CsrfTokenHtml}}
+										<input type="hidden" name="action" value="mirror">
+										<div class="inline field {{if .Err_EnablePrune}}error{{end}}">
+											<label>{{ctx.Locale.Tr "repo.mirror_prune"}}</label>
+											<div class="ui checkbox">
+										<input id="enable_prune" name="enable_prune" type="checkbox" {{if .PullMirror.EnablePrune}}checked{{end}}>
+										<label>{{ctx.Locale.Tr "repo.mirror_prune_desc"}}</label>
+											</div>
+										</div>
+										<div class="inline field {{if .Err_Interval}}error{{end}}">
+											<label for="interval">{{ctx.Locale.Tr "repo.mirror_interval" .MinimumMirrorInterval}}</label>
+											<input id="interval" name="interval" value="{{.PullMirror.Interval}}">
+										</div>
+										{{$address := MirrorRemoteAddress ctx .Repository .PullMirror.GetRemoteName}}
+										<div class="field {{if .Err_MirrorAddress}}error{{end}}">
+											<label for="mirror_address">{{ctx.Locale.Tr "repo.mirror_address"}}</label>
+											<input id="mirror_address" name="mirror_address" value="{{$address.Address}}" required>
+											<p class="help">{{ctx.Locale.Tr "repo.mirror_address_desc"}}</p>
+										</div>
+										<details class="ui optional field" {{if or .Err_Auth $address.Username}}open{{end}}>
+											<summary class="tw-p-1">
+												{{ctx.Locale.Tr "repo.need_auth"}}
+											</summary>
+											<div class="tw-p-1">
+												<div class="inline field {{if .Err_Auth}}error{{end}}">
+													<label for="mirror_username">{{ctx.Locale.Tr "username"}}</label>
+													<input id="mirror_username" name="mirror_username" value="{{$address.Username}}" {{if not .mirror_username}}data-need-clear="true"{{end}}>
+												</div>
+												<div class="inline field {{if .Err_Auth}}error{{end}}">
+													<label for="mirror_password">{{ctx.Locale.Tr "password"}}</label>
+													<input id="mirror_password" name="mirror_password" type="password" placeholder="{{if $address.Password}}{{ctx.Locale.Tr "repo.mirror_password_placeholder"}}{{else}}{{ctx.Locale.Tr "repo.mirror_password_blank_placeholder"}}{{end}}" value="" {{if not .mirror_password}}data-need-clear="true"{{end}} autocomplete="off">
+												</div>
+												<p class="help">{{ctx.Locale.Tr "repo.mirror_password_help"}}</p>
+											</div>
+										</details>
+
+										{{if .LFSStartServer}}
+										<div class="inline field">
+											<label>{{ctx.Locale.Tr "repo.mirror_lfs"}}</label>
+											<div class="ui checkbox">
+												<input id="mirror_lfs" name="mirror_lfs" type="checkbox" {{if .PullMirror.LFS}}checked{{end}}>
+												<label>{{ctx.Locale.Tr "repo.mirror_lfs_desc"}}</label>
+											</div>
+										</div>
+										<div class="field {{if .Err_LFSEndpoint}}error{{end}}">
+											<label for="mirror_lfs_endpoint">{{ctx.Locale.Tr "repo.mirror_lfs_endpoint"}}</label>
+											<input id="mirror_lfs_endpoint" name="mirror_lfs_endpoint" value="{{.PullMirror.LFSEndpoint}}" placeholder="{{ctx.Locale.Tr "repo.migrate_options_lfs_endpoint.placeholder"}}">
+											<p class="help">{{ctx.Locale.Tr "repo.mirror_lfs_endpoint_desc" "https://github.com/git-lfs/git-lfs/blob/main/docs/api/server-discovery.md#server-discovery"}}</p>
+										</div>
+										{{end}}
+										<div class="field">
+											<button class="ui primary button">{{ctx.Locale.Tr "repo.settings.update_mirror_settings"}}</button>
+										</div>
+									</form>
+								</td>
+							</tr>
+						</tbody>
+						{{end}}{{/* end if: $modifyBrokenPullMirror / $isWorkingPullMirror */}}
+					</table>
+					{{end}}{{/* end if .Repository.IsMirror */}}
+
+					<table class="ui table">
+						<thead>
+							<tr>
+								<th class="tw-w-2/5">{{ctx.Locale.Tr "repo.settings.mirror_settings.pushed_repository"}}</th>
+								<th>{{ctx.Locale.Tr "repo.settings.mirror_settings.direction"}}</th>
+								<th>{{ctx.Locale.Tr "repo.settings.mirror_settings.last_update"}}</th>
+								<th></th>
+							</tr>
+						</thead>
+						<tbody>
+							{{range .PushMirrors}}
+							<tr>
+								<td class="tw-break-anywhere">{{.RemoteAddress}}</td>
+								<td>{{ctx.Locale.Tr "repo.settings.mirror_settings.direction.push"}} ({{.Interval}})</td>
+								<td>
+									<span class="flex-text-block">
+										{{if .LastUpdateUnix}}
+											{{DateUtils.FullTime .LastUpdateUnix}}
+										{{else}}
+											{{ctx.Locale.Tr "never"}}
+										{{end}}
+										{{if .LastError}}<span class="ui red label" data-tooltip-content="{{.LastError}}">{{ctx.Locale.Tr "error"}}</span>{{end}}
+									</span>
+								</td>
+								<td class="tw-text-right">
+									<button
+										class="ui tiny button show-modal"
+										data-modal="#push-mirror-edit-modal"
+										data-tooltip-content="{{ctx.Locale.Tr "repo.settings.mirror_settings.push_mirror.edit_sync_time"}}"
+										data-modal-push-mirror-edit-id="{{.ID}}"
+										data-modal-push-mirror-edit-interval="{{.Interval}}"
+										data-modal-push-mirror-edit-address="{{.RemoteAddress}}"
+									>
+										{{svg "octicon-pencil" 14}}
+									</button>
+									<form method="post" class="tw-inline-block">
+										{{$.CsrfTokenHtml}}
+										<input type="hidden" name="action" value="push-mirror-sync">
+										<input type="hidden" name="push_mirror_id" value="{{.ID}}">
+										<button class="ui primary tiny button" data-tooltip-content="{{ctx.Locale.Tr "repo.settings.sync_mirror"}}">{{svg "octicon-sync" 14}}</button>
+									</form>
+									<form method="post" class="tw-inline-block">
+										{{$.CsrfTokenHtml}}
+										<input type="hidden" name="action" value="push-mirror-remove">
+										<input type="hidden" name="push_mirror_id" value="{{.ID}}">
+										<button class="ui basic red tiny button" data-tooltip-content="{{ctx.Locale.Tr "remove"}}">{{svg "octicon-trash" 14}}</button>
+									</form>
+								</td>
+							</tr>
+							{{else}}
+							<tr>
+								<td>{{ctx.Locale.Tr "repo.settings.mirror_settings.push_mirror.none"}}</td>
+							</tr>
+							{{end}}
+							{{if (not .DisableNewPushMirrors)}}
+								<tr>
+									<td colspan="4">
+										<form class="ui form" method="post">
+											{{template "base/disable_form_autofill"}}
+											{{.CsrfTokenHtml}}
+											<input type="hidden" name="action" value="push-mirror-add">
+											<div class="field {{if .Err_PushMirrorAddress}}error{{end}}">
+												<label for="push_mirror_address">{{ctx.Locale.Tr "repo.settings.mirror_settings.push_mirror.remote_url"}}</label>
+												<input id="push_mirror_address" name="push_mirror_address" value="{{.push_mirror_address}}" required>
+												<p class="help">{{ctx.Locale.Tr "repo.mirror_address_desc"}}</p>
+											</div>
+											<details class="ui optional field" {{if or .Err_PushMirrorAuth .push_mirror_username}}open{{end}}>
+												<summary class="tw-p-1">
+													{{ctx.Locale.Tr "repo.need_auth"}}
+												</summary>
+												<div class="tw-p-1">
+													<div class="inline field {{if .Err_PushMirrorAuth}}error{{end}}">
+														<label for="push_mirror_username">{{ctx.Locale.Tr "username"}}</label>
+														<input id="push_mirror_username" name="push_mirror_username" value="{{.push_mirror_username}}">
+													</div>
+													<div class="inline field {{if .Err_PushMirrorAuth}}error{{end}}">
+														<label for="push_mirror_password">{{ctx.Locale.Tr "password"}}</label>
+														<input id="push_mirror_password" name="push_mirror_password" type="password" value="{{.push_mirror_password}}" autocomplete="off">
+													</div>
+												</div>
+											</details>
+											<div class="field">
+												<div class="ui checkbox">
+													<input id="push_mirror_sync_on_commit" name="push_mirror_sync_on_commit" type="checkbox" {{if .push_mirror_sync_on_commit}}checked{{end}}>
+													<label for="push_mirror_sync_on_commit">{{ctx.Locale.Tr "repo.mirror_sync_on_commit"}}</label>
+												</div>
+											</div>
+											<div class="inline field {{if .Err_PushMirrorInterval}}error{{end}}">
+												<label for="push_mirror_interval">{{ctx.Locale.Tr "repo.mirror_interval" .MinimumMirrorInterval}}</label>
+												<input id="push_mirror_interval" name="push_mirror_interval" value="{{if .push_mirror_interval}}{{.push_mirror_interval}}{{else}}{{.DefaultMirrorInterval}}{{end}}">
+											</div>
+											<div class="field">
+												<button class="ui primary button">{{ctx.Locale.Tr "repo.settings.mirror_settings.push_mirror.add"}}</button>
+											</div>
+										</form>
+									</td>
+								</tr>
+							{{end}}
+						</tbody>
+					</table>
+				{{end}}
+			</div>
+		{{end}}
+
+		<h4 class="ui top attached header">
+			{{ctx.Locale.Tr "repo.settings.advanced_settings"}}
+		</h4>
+		<div class="ui attached segment">
+			<form class="ui form" method="post">
+				{{.CsrfTokenHtml}}
+				<input type="hidden" name="action" value="advanced">
+
+				{{$isCodeEnabled := .Repository.UnitEnabled ctx ctx.Consts.RepoUnitTypeCode}}
+				{{$isCodeGlobalDisabled := ctx.Consts.RepoUnitTypeCode.UnitGlobalDisabled}}
+				<div class="inline field">
+					<label>{{ctx.Locale.Tr "repo.code"}}</label>
+					<div class="ui checkbox{{if $isCodeGlobalDisabled}} disabled{{end}}"{{if $isCodeGlobalDisabled}} data-tooltip-content="{{ctx.Locale.Tr "repo.unit_disabled"}}"{{end}}>
+						<input class="enable-system" name="enable_code" type="checkbox"{{if $isCodeEnabled}} checked{{end}}>
+						<label>{{ctx.Locale.Tr "repo.code.desc"}}</label>
+					</div>
+				</div>
+
+				{{$isInternalWikiEnabled := .Repository.UnitEnabled ctx ctx.Consts.RepoUnitTypeWiki}}
+				{{$isExternalWikiEnabled := .Repository.UnitEnabled ctx ctx.Consts.RepoUnitTypeExternalWiki}}
+				{{$isWikiEnabled := or $isInternalWikiEnabled $isExternalWikiEnabled}}
+				{{$isWikiGlobalDisabled := ctx.Consts.RepoUnitTypeWiki.UnitGlobalDisabled}}
+				{{$isExternalWikiGlobalDisabled := ctx.Consts.RepoUnitTypeExternalWiki.UnitGlobalDisabled}}
+				{{$isBothWikiGlobalDisabled := and $isWikiGlobalDisabled $isExternalWikiGlobalDisabled}}
+				<div class="inline field">
+					<label>{{ctx.Locale.Tr "repo.wiki"}}</label>
+					<div class="ui checkbox{{if $isBothWikiGlobalDisabled}} disabled{{end}}"{{if $isBothWikiGlobalDisabled}} data-tooltip-content="{{ctx.Locale.Tr "repo.unit_disabled"}}"{{end}}>
+						<input class="enable-system" name="enable_wiki" type="checkbox" data-target="#wiki_box" {{if $isWikiEnabled}}checked{{end}}>
+						<label>{{ctx.Locale.Tr "repo.settings.wiki_desc"}}</label>
+					</div>
+				</div>
+				<div class="field{{if not $isWikiEnabled}} disabled{{end}}" id="wiki_box">
+					<div class="field">
+						<div class="ui radio checkbox{{if $isWikiGlobalDisabled}} disabled{{end}}"{{if $isWikiGlobalDisabled}} data-tooltip-content="{{ctx.Locale.Tr "repo.unit_disabled"}}"{{end}}>
+							<input class="enable-system-radio" name="enable_external_wiki" type="radio" value="false" data-context="#internal_wiki_box" data-target="#external_wiki_box" {{if $isInternalWikiEnabled}}checked{{end}}>
+							<label>{{ctx.Locale.Tr "repo.settings.use_internal_wiki"}}</label>
+						</div>
+					</div>
+					<div id="internal_wiki_box" class="field tw-pl-4 {{if not $isInternalWikiEnabled}}disabled{{end}}">
+						<div class="inline field">
+							<label>{{ctx.Locale.Tr "repo.settings.default_wiki_branch_name"}}</label>
+							<input name="default_wiki_branch" value="{{.Repository.DefaultWikiBranch}}">
+						</div>
+					</div>
+					<div class="field">
+						<div class="ui radio checkbox{{if $isExternalWikiGlobalDisabled}} disabled{{end}}"{{if $isExternalWikiGlobalDisabled}} data-tooltip-content="{{ctx.Locale.Tr "repo.unit_disabled"}}"{{end}}>
+							<input class="enable-system-radio" name="enable_external_wiki" type="radio" value="true" data-context="#internal_wiki_box" data-target="#external_wiki_box" {{if $isExternalWikiEnabled}}checked{{end}}>
+							<label>{{ctx.Locale.Tr "repo.settings.use_external_wiki"}}</label>
+						</div>
+					</div>
+					<div id="external_wiki_box" class="field tw-pl-4 {{if not $isExternalWikiEnabled}}disabled{{end}}">
+						<label for="external_wiki_url">{{ctx.Locale.Tr "repo.settings.external_wiki_url"}}</label>
+						<input id="external_wiki_url" name="external_wiki_url" type="url" value="{{(.Repository.MustGetUnit ctx ctx.Consts.RepoUnitTypeExternalWiki).ExternalWikiConfig.ExternalWikiURL}}">
+						<p class="help">{{ctx.Locale.Tr "repo.settings.external_wiki_url_desc"}}</p>
+					</div>
+				</div>
+
+				<div class="divider"></div>
+
+				{{$isIssuesEnabled := or (.Repository.UnitEnabled ctx ctx.Consts.RepoUnitTypeIssues) (.Repository.UnitEnabled ctx ctx.Consts.RepoUnitTypeExternalTracker)}}
+				{{$isIssuesGlobalDisabled := ctx.Consts.RepoUnitTypeIssues.UnitGlobalDisabled}}
+				{{$isExternalTrackerGlobalDisabled := ctx.Consts.RepoUnitTypeExternalTracker.UnitGlobalDisabled}}
+				{{$isIssuesAndExternalGlobalDisabled := and $isIssuesGlobalDisabled $isExternalTrackerGlobalDisabled}}
+				<div class="inline field">
+					<label>{{ctx.Locale.Tr "repo.issues"}}</label>
+					<div class="ui checkbox{{if $isIssuesAndExternalGlobalDisabled}} disabled{{end}}"{{if $isIssuesAndExternalGlobalDisabled}} data-tooltip-content="{{ctx.Locale.Tr "repo.unit_disabled"}}"{{end}}>
+						<input class="enable-system" name="enable_issues" type="checkbox" data-target="#issue_box" {{if $isIssuesEnabled}}checked{{end}}>
+						<label>{{ctx.Locale.Tr "repo.settings.issues_desc"}}</label>
+					</div>
+				</div>
+				<div class="field {{if not $isIssuesEnabled}}disabled{{end}}" id="issue_box">
+					<div class="field">
+						<div class="ui radio checkbox{{if $isIssuesGlobalDisabled}} disabled{{end}}"{{if $isIssuesGlobalDisabled}} data-tooltip-content="{{ctx.Locale.Tr "repo.unit_disabled"}}"{{end}}>
+							<input class="enable-system-radio" name="enable_external_tracker" type="radio" value="false" data-context="#internal_issue_box" data-target="#external_issue_box" {{if not (.Repository.UnitEnabled ctx ctx.Consts.RepoUnitTypeExternalTracker)}}checked{{end}}>
+							<label>{{ctx.Locale.Tr "repo.settings.use_internal_issue_tracker"}}</label>
+						</div>
+					</div>
+					<div class="field tw-pl-4 {{if (.Repository.UnitEnabled ctx ctx.Consts.RepoUnitTypeExternalTracker)}}disabled{{end}}" id="internal_issue_box">
+						{{if .Repository.CanEnableTimetracker}}
+							<div class="field">
+								<div class="ui checkbox">
+									<input name="enable_timetracker" class="enable-system" data-target="#only_contributors" type="checkbox" {{if .Repository.IsTimetrackerEnabled ctx}}checked{{end}}>
+									<label>{{ctx.Locale.Tr "repo.settings.enable_timetracker"}}</label>
+								</div>
+							</div>
+							<div class="field {{if not (.Repository.IsTimetrackerEnabled ctx)}}disabled{{end}}" id="only_contributors">
+								<div class="ui checkbox">
+									<input name="allow_only_contributors_to_track_time" type="checkbox" {{if .Repository.AllowOnlyContributorsToTrackTime ctx}}checked{{end}}>
+									<label>{{ctx.Locale.Tr "repo.settings.allow_only_contributors_to_track_time"}}</label>
+								</div>
+							</div>
+						{{end}}
+						<div class="field">
+							<div class="ui checkbox">
+								<input name="enable_issue_dependencies" type="checkbox" {{if (.Repository.IsDependenciesEnabled ctx)}}checked{{end}}>
+								<label>{{ctx.Locale.Tr "repo.issues.dependency.setting"}}</label>
+							</div>
+						</div>
+						<div class="ui checkbox">
+							<input name="enable_close_issues_via_commit_in_any_branch" type="checkbox" {{if .Repository.CloseIssuesViaCommitInAnyBranch}}checked{{end}}>
+							<label>{{ctx.Locale.Tr "repo.settings.admin_enable_close_issues_via_commit_in_any_branch"}}</label>
+						</div>
+					</div>
+					<div class="field">
+						<div class="ui radio checkbox{{if $isExternalTrackerGlobalDisabled}} disabled{{end}}"{{if $isExternalTrackerGlobalDisabled}} data-tooltip-content="{{ctx.Locale.Tr "repo.unit_disabled"}}"{{end}}>
+							<input class="enable-system-radio" name="enable_external_tracker" type="radio" value="true" data-context="#internal_issue_box" data-target="#external_issue_box" {{if .Repository.UnitEnabled ctx ctx.Consts.RepoUnitTypeExternalTracker}}checked{{end}}>
+							<label>{{ctx.Locale.Tr "repo.settings.use_external_issue_tracker"}}</label>
+						</div>
+					</div>
+					<div class="field tw-pl-4 {{if not (.Repository.UnitEnabled ctx ctx.Consts.RepoUnitTypeExternalTracker)}}disabled{{end}}" id="external_issue_box">
+						<div class="field">
+							<label for="external_tracker_url">{{ctx.Locale.Tr "repo.settings.external_tracker_url"}}</label>
+							<input id="external_tracker_url" name="external_tracker_url" type="url" value="{{(.Repository.MustGetUnit ctx ctx.Consts.RepoUnitTypeExternalTracker).ExternalTrackerConfig.ExternalTrackerURL}}">
+							<p class="help">{{ctx.Locale.Tr "repo.settings.external_tracker_url_desc"}}</p>
+						</div>
+						<div class="field">
+							<label for="tracker_url_format">{{ctx.Locale.Tr "repo.settings.tracker_url_format"}}</label>
+							<input id="tracker_url_format" name="tracker_url_format" type="url" value="{{(.Repository.MustGetUnit ctx ctx.Consts.RepoUnitTypeExternalTracker).ExternalTrackerConfig.ExternalTrackerFormat}}" placeholder="https://github.com/{user}/{repo}/issues/{index}">
+							<p class="help">{{ctx.Locale.Tr "repo.settings.tracker_url_format_desc"}}</p>
+						</div>
+						<div class="inline fields">
+							<label for="issue_style">{{ctx.Locale.Tr "repo.settings.tracker_issue_style"}}</label>
+							<div class="field">
+								<div class="ui radio checkbox">
+								{{$externalTracker := (.Repository.MustGetUnit ctx ctx.Consts.RepoUnitTypeExternalTracker)}}
+								{{$externalTrackerStyle := $externalTracker.ExternalTrackerConfig.ExternalTrackerStyle}}
+									<input class="js-tracker-issue-style" name="tracker_issue_style" type="radio" value="numeric" {{if eq $externalTrackerStyle "numeric"}}checked{{end}}>
+									<label>{{ctx.Locale.Tr "repo.settings.tracker_issue_style.numeric"}} <span class="ui light grey text">#1234</span></label>
+								</div>
+							</div>
+							<div class="field">
+								<div class="ui radio checkbox">
+									<input class="js-tracker-issue-style" name="tracker_issue_style" type="radio" value="alphanumeric" {{if eq $externalTrackerStyle "alphanumeric"}}checked{{end}}>
+									<label>{{ctx.Locale.Tr "repo.settings.tracker_issue_style.alphanumeric"}} <span class="ui light grey text">ABC-123 , DEFG-234</span></label>
+								</div>
+							</div>
+							<div class="field">
+								<div class="ui radio checkbox">
+									<input class="js-tracker-issue-style" name="tracker_issue_style" type="radio" value="regexp" {{if eq $externalTrackerStyle "regexp"}}checked{{end}}>
+									<label>{{ctx.Locale.Tr "repo.settings.tracker_issue_style.regexp"}} <span class="ui light grey text">(ISSUE-\d+) , ISSUE-(\d+)</span></label>
+								</div>
+							</div>
+						</div>
+						<div class="field {{if ne $externalTrackerStyle "regexp"}}disabled{{end}}" id="tracker-issue-style-regex-box">
+							<label for="external_tracker_regexp_pattern">{{ctx.Locale.Tr "repo.settings.tracker_issue_style.regexp_pattern"}}</label>
+							<input id="external_tracker_regexp_pattern" name="external_tracker_regexp_pattern" value="{{(.Repository.MustGetUnit ctx ctx.Consts.RepoUnitTypeExternalTracker).ExternalTrackerConfig.ExternalTrackerRegexpPattern}}">
+							<p class="help">{{ctx.Locale.Tr "repo.settings.tracker_issue_style.regexp_pattern_desc"}}</p>
+						</div>
+					</div>
+				</div>
+
+				<div class="divider"></div>
+
+				{{$isProjectsEnabled := .Repository.UnitEnabled ctx ctx.Consts.RepoUnitTypeProjects}}
+				{{$isProjectsGlobalDisabled := ctx.Consts.RepoUnitTypeProjects.UnitGlobalDisabled}}
+				{{$projectsUnit := .Repository.MustGetUnit ctx ctx.Consts.RepoUnitTypeProjects}}
+				<div class="inline field">
+					<label>{{ctx.Locale.Tr "repo.projects"}}</label>
+					<div class="ui checkbox{{if $isProjectsGlobalDisabled}} disabled{{end}}"{{if $isProjectsGlobalDisabled}} data-tooltip-content="{{ctx.Locale.Tr "repo.unit_disabled"}}"{{end}}>
+						<input class="enable-system" name="enable_projects" type="checkbox" data-target="#projects_box" {{if $isProjectsEnabled}}checked{{end}}>
+						<label>{{ctx.Locale.Tr "repo.settings.projects_desc"}}</label>
+					</div>
+				</div>
+				<div class="field {{if not $isProjectsEnabled}} disabled{{end}} tw-pl-4" id="projects_box">
+					<p>
+						{{ctx.Locale.Tr "repo.settings.projects_mode_desc"}}
+					</p>
+					<div class="ui dropdown selection">
+						<select name="projects_mode">
+							<option value="repo" {{if or (not $isProjectsEnabled) (eq $projectsUnit.ProjectsConfig.GetProjectsMode "repo")}}selected{{end}}>{{ctx.Locale.Tr "repo.settings.projects_mode_repo"}}</option>
+							<option value="owner" {{if or (not $isProjectsEnabled) (eq $projectsUnit.ProjectsConfig.GetProjectsMode "owner")}}selected{{end}}>{{ctx.Locale.Tr "repo.settings.projects_mode_owner"}}</option>
+							<option value="all" {{if or (not $isProjectsEnabled) (eq $projectsUnit.ProjectsConfig.GetProjectsMode "all")}}selected{{end}}>{{ctx.Locale.Tr "repo.settings.projects_mode_all"}}</option>
+						</select>
+						{{svg "octicon-triangle-down" 14 "dropdown icon"}}
+						<div class="default text">
+							{{if (eq $projectsUnit.ProjectsConfig.GetProjectsMode "repo")}}
+								{{ctx.Locale.Tr "repo.settings.projects_mode_repo"}}
+							{{end}}
+							{{if (eq $projectsUnit.ProjectsConfig.GetProjectsMode "owner")}}
+								{{ctx.Locale.Tr "repo.settings.projects_mode_owner"}}
+							{{end}}
+							{{if (eq $projectsUnit.ProjectsConfig.GetProjectsMode "all")}}
+								{{ctx.Locale.Tr "repo.settings.projects_mode_all"}}
+							{{end}}
+						</div>
+						<div class="menu">
+							<div class="item" data-value="repo">{{ctx.Locale.Tr "repo.settings.projects_mode_repo"}}</div>
+							<div class="item" data-value="owner">{{ctx.Locale.Tr "repo.settings.projects_mode_owner"}}</div>
+							<div class="item" data-value="all">{{ctx.Locale.Tr "repo.settings.projects_mode_all"}}</div>
+						</div>
+					</div>
+				</div>
+
+				<div class="divider"></div>
+
+				{{$isReleasesEnabled := .Repository.UnitEnabled ctx ctx.Consts.RepoUnitTypeReleases}}
+				{{$isReleasesGlobalDisabled := ctx.Consts.RepoUnitTypeReleases.UnitGlobalDisabled}}
+				<div class="inline field">
+					<label>{{ctx.Locale.Tr "repo.releases"}}</label>
+					<div class="ui checkbox{{if $isReleasesGlobalDisabled}} disabled{{end}}"{{if $isReleasesGlobalDisabled}} data-tooltip-content="{{ctx.Locale.Tr "repo.unit_disabled"}}"{{end}}>
+						<input class="enable-system" name="enable_releases" type="checkbox" {{if $isReleasesEnabled}}checked{{end}}>
+						<label>{{ctx.Locale.Tr "repo.settings.releases_desc"}}</label>
+					</div>
+				</div>
+
+				{{$isPackagesEnabled := .Repository.UnitEnabled ctx ctx.Consts.RepoUnitTypePackages}}
+				{{$isPackagesGlobalDisabled := ctx.Consts.RepoUnitTypePackages.UnitGlobalDisabled}}
+				<div class="inline field">
+					<label>{{ctx.Locale.Tr "repo.packages"}}</label>
+					<div class="ui checkbox{{if $isPackagesGlobalDisabled}} disabled{{end}}"{{if $isPackagesGlobalDisabled}} data-tooltip-content="{{ctx.Locale.Tr "repo.unit_disabled"}}"{{end}}>
+						<input class="enable-system" name="enable_packages" type="checkbox" {{if $isPackagesEnabled}}checked{{end}}>
+						<label>{{ctx.Locale.Tr "repo.settings.packages_desc"}}</label>
+					</div>
+				</div>
+
+				{{if .EnableActions}}
+					{{$isActionsEnabled := .Repository.UnitEnabled ctx ctx.Consts.RepoUnitTypeActions}}
+					{{$isActionsGlobalDisabled := ctx.Consts.RepoUnitTypeActions.UnitGlobalDisabled}}
+					<div class="inline field">
+						<label>{{ctx.Locale.Tr "actions.actions"}}</label>
+							<div class="ui checkbox{{if $isActionsGlobalDisabled}} disabled{{end}}"{{if $isActionsGlobalDisabled}} data-tooltip-content="{{ctx.Locale.Tr "repo.unit_disabled"}}"{{end}}>
+							<input class="enable-system" name="enable_actions" type="checkbox" {{if $isActionsEnabled}}checked{{end}}>
+							<label>{{ctx.Locale.Tr "repo.settings.actions_desc"}}</label>
+						</div>
+					</div>
+				{{end}}
+
+				{{if not .IsMirror}}
+					<div class="divider"></div>
+					{{$pullRequestEnabled := .Repository.UnitEnabled ctx ctx.Consts.RepoUnitTypePullRequests}}
+					{{$pullRequestGlobalDisabled := ctx.Consts.RepoUnitTypePullRequests.UnitGlobalDisabled}}
+					{{$prUnit := .Repository.MustGetUnit ctx ctx.Consts.RepoUnitTypePullRequests}}
+					<div class="inline field">
+						<label>{{ctx.Locale.Tr "repo.pulls"}}</label>
+						<div class="ui checkbox{{if $pullRequestGlobalDisabled}} disabled{{end}}"{{if $pullRequestGlobalDisabled}} data-tooltip-content="{{ctx.Locale.Tr "repo.unit_disabled"}}"{{end}}>
+							<input class="enable-system" name="enable_pulls" type="checkbox" data-target="#pull_box" {{if $pullRequestEnabled}}checked{{end}}>
+							<label>{{ctx.Locale.Tr "repo.settings.pulls_desc"}}</label>
+						</div>
+					</div>
+					<div class="field{{if not $pullRequestEnabled}} disabled{{end}}" id="pull_box">
+						<div class="field">
+							<p>
+								{{ctx.Locale.Tr "repo.settings.merge_style_desc"}}
+							</p>
+						</div>
+						<div class="field">
+							<div class="ui checkbox">
+								<input name="pulls_allow_merge" type="checkbox" {{if or (not $pullRequestEnabled) ($prUnit.PullRequestsConfig.AllowMerge)}}checked{{end}}>
+								<label>{{ctx.Locale.Tr "repo.pulls.merge_pull_request"}}</label>
+							</div>
+						</div>
+						<div class="field">
+							<div class="ui checkbox">
+								<input name="pulls_allow_rebase" type="checkbox" {{if or (not $pullRequestEnabled) ($prUnit.PullRequestsConfig.AllowRebase)}}checked{{end}}>
+								<label>{{ctx.Locale.Tr "repo.pulls.rebase_merge_pull_request"}}</label>
+							</div>
+						</div>
+						<div class="field">
+							<div class="ui checkbox">
+								<input name="pulls_allow_rebase_merge" type="checkbox" {{if or (not $pullRequestEnabled) ($prUnit.PullRequestsConfig.AllowRebaseMerge)}}checked{{end}}>
+								<label>{{ctx.Locale.Tr "repo.pulls.rebase_merge_commit_pull_request"}}</label>
+							</div>
+						</div>
+						<div class="field">
+							<div class="ui checkbox">
+								<input name="pulls_allow_squash" type="checkbox" {{if or (not $pullRequestEnabled) ($prUnit.PullRequestsConfig.AllowSquash)}}checked{{end}}>
+								<label>{{ctx.Locale.Tr "repo.pulls.squash_merge_pull_request"}}</label>
+							</div>
+						</div>
+						<div class="field">
+							<div class="ui checkbox">
+								<input name="pulls_allow_fast_forward_only" type="checkbox" {{if or (not $pullRequestEnabled) ($prUnit.PullRequestsConfig.AllowFastForwardOnly)}}checked{{end}}>
+								<label>{{ctx.Locale.Tr "repo.pulls.fast_forward_only_merge_pull_request"}}</label>
+							</div>
+						</div>
+						<div class="field">
+							<div class="ui checkbox">
+								<input name="pulls_allow_manual_merge" type="checkbox" {{if or (not $pullRequestEnabled) ($prUnit.PullRequestsConfig.AllowManualMerge)}}checked{{end}}>
+								<label>{{ctx.Locale.Tr "repo.pulls.merge_manually"}}</label>
+							</div>
+						</div>
+
+						<div class="field">
+							<p>
+								{{ctx.Locale.Tr "repo.settings.default_merge_style_desc"}}
+							</p>
+							<div class="ui dropdown selection">
+								<select name="pulls_default_merge_style">
+									<option value="merge" {{if or (not $pullRequestEnabled) (eq $prUnit.PullRequestsConfig.DefaultMergeStyle "merge")}}selected{{end}}>{{ctx.Locale.Tr "repo.pulls.merge_pull_request"}}</option>
+									<option value="rebase" {{if or (not $pullRequestEnabled) (eq $prUnit.PullRequestsConfig.DefaultMergeStyle "rebase")}}selected{{end}}>{{ctx.Locale.Tr "repo.pulls.rebase_merge_pull_request"}}</option>
+									<option value="rebase-merge" {{if or (not $pullRequestEnabled) (eq $prUnit.PullRequestsConfig.DefaultMergeStyle "rebase-merge")}}selected{{end}}>{{ctx.Locale.Tr "repo.pulls.rebase_merge_commit_pull_request"}}</option>
+									<option value="squash" {{if or (not $pullRequestEnabled) (eq $prUnit.PullRequestsConfig.DefaultMergeStyle "squash")}}selected{{end}}>{{ctx.Locale.Tr "repo.pulls.squash_merge_pull_request"}}</option>
+									<option value="fast-forward-only" {{if or (not $pullRequestEnabled) (eq $prUnit.PullRequestsConfig.DefaultMergeStyle "fast-forward-only")}}selected{{end}}>{{ctx.Locale.Tr "repo.pulls.fast_forward_only_merge_pull_request"}}</option>
+								</select>{{svg "octicon-triangle-down" 14 "dropdown icon"}}
+								<div class="default text">
+									{{if (eq $prUnit.PullRequestsConfig.DefaultMergeStyle "merge")}}
+										{{ctx.Locale.Tr "repo.pulls.merge_pull_request"}}
+									{{end}}
+									{{if (eq $prUnit.PullRequestsConfig.DefaultMergeStyle "rebase")}}
+										{{ctx.Locale.Tr "repo.pulls.rebase_merge_pull_request"}}
+									{{end}}
+									{{if (eq $prUnit.PullRequestsConfig.DefaultMergeStyle "rebase-merge")}}
+										{{ctx.Locale.Tr "repo.pulls.rebase_merge_commit_pull_request"}}
+									{{end}}
+									{{if (eq $prUnit.PullRequestsConfig.DefaultMergeStyle "squash")}}
+										{{ctx.Locale.Tr "repo.pulls.squash_merge_pull_request"}}
+									{{end}}
+									{{if (eq $prUnit.PullRequestsConfig.DefaultMergeStyle "fast-forward-only")}}
+										{{ctx.Locale.Tr "repo.pulls.fast_forward_only_merge_pull_request"}}
+									{{end}}
+								</div>
+								<div class="menu">
+									<div class="item" data-value="merge">{{ctx.Locale.Tr "repo.pulls.merge_pull_request"}}</div>
+									<div class="item" data-value="rebase">{{ctx.Locale.Tr "repo.pulls.rebase_merge_pull_request"}}</div>
+									<div class="item" data-value="rebase-merge">{{ctx.Locale.Tr "repo.pulls.rebase_merge_commit_pull_request"}}</div>
+									<div class="item" data-value="squash">{{ctx.Locale.Tr "repo.pulls.squash_merge_pull_request"}}</div>
+									<div class="item" data-value="fast-forward-only">{{ctx.Locale.Tr "repo.pulls.fast_forward_only_merge_pull_request"}}</div>
+								</div>
+							</div>
+						</div>
+						<div class="field">
+							<div class="ui checkbox">
+								<input name="default_allow_maintainer_edit" type="checkbox" {{if or (not $pullRequestEnabled) ($prUnit.PullRequestsConfig.DefaultAllowMaintainerEdit)}}checked{{end}}>
+								<label>{{ctx.Locale.Tr "repo.settings.pulls.default_allow_edits_from_maintainers"}}</label>
+							</div>
+						</div>
+						<div class="field">
+							<div class="ui checkbox">
+								<input name="pulls_allow_rebase_update" type="checkbox" {{if or (not $pullRequestEnabled) ($prUnit.PullRequestsConfig.AllowRebaseUpdate)}}checked{{end}}>
+								<label>{{ctx.Locale.Tr "repo.settings.pulls.allow_rebase_update"}}</label>
+							</div>
+						</div>
+
+						<div class="field">
+							<div class="ui checkbox">
+								<input name="enable_autodetect_manual_merge" type="checkbox" {{if or (not $pullRequestEnabled) ($prUnit.PullRequestsConfig.AutodetectManualMerge)}}checked{{end}}>
+								<label>{{ctx.Locale.Tr "repo.settings.pulls.enable_autodetect_manual_merge"}}</label>
+							</div>
+						</div>
+						<div class="field">
+							<div class="ui checkbox">
+								<input name="pulls_ignore_whitespace" type="checkbox" {{if and $pullRequestEnabled ($prUnit.PullRequestsConfig.IgnoreWhitespaceConflicts)}}checked{{end}}>
+								<label>{{ctx.Locale.Tr "repo.settings.pulls.ignore_whitespace"}}</label>
+							</div>
+						</div>
+					</div>
+				{{end}}
+
+				<div class="divider"></div>
+				<div class="field">
+					<button class="ui primary button">{{ctx.Locale.Tr "repo.settings.update_settings"}}</button>
+				</div>
+			</form>
+		</div>
+
+		<h4 class="ui top attached header">
+			{{ctx.Locale.Tr "repo.settings.signing_settings"}}
+		</h4>
+		<div class="ui attached segment">
+			<form class="ui form" method="post">
+				{{.CsrfTokenHtml}}
+				<input type="hidden" name="action" value="signing">
+				<div class="field">
+					<label>{{ctx.Locale.Tr "repo.settings.trust_model"}}</label><br>
+					<div class="field">
+						<div class="ui radio checkbox">
+							<input type="radio" id="trust_model_default" name="trust_model" {{if eq .Repository.TrustModel.String "default"}}checked="checked"{{end}} value="default">
+							<label for="trust_model_default">{{ctx.Locale.Tr "repo.settings.trust_model.default"}}</label>
+							<p class="help">{{ctx.Locale.Tr "repo.settings.trust_model.default.desc"}}</p>
+						</div>
+					</div>
+					<div class="field">
+						<div class="ui radio checkbox">
+							<input type="radio" id="trust_model_collaborator" name="trust_model" {{if eq .Repository.TrustModel.String "collaborator"}}checked="checked"{{end}} value="collaborator">
+							<label for="trust_model_collaborator">{{ctx.Locale.Tr "repo.settings.trust_model.collaborator.long"}}</label>
+							<p class="help">{{ctx.Locale.Tr "repo.settings.trust_model.collaborator.desc"}}</p>
+						</div>
+					</div>
+					<div class="field">
+						<div class="ui radio checkbox">
+							<input type="radio" name="trust_model" id="trust_model_committer" {{if eq .Repository.TrustModel.String "committer"}}checked="checked"{{end}} value="committer">
+							<label for="trust_model_committer">{{ctx.Locale.Tr "repo.settings.trust_model.committer.long"}}</label>
+							<p class="help">{{ctx.Locale.Tr "repo.settings.trust_model.committer.desc"}}</p>
+						</div>
+					</div>
+					<div class="field">
+						<div class="ui radio checkbox">
+							<input type="radio" name="trust_model" id="trust_model_collaboratorcommitter" {{if eq .Repository.TrustModel.String "collaboratorcommitter"}}checked="checked"{{end}} value="collaboratorcommitter">
+							<label for="trust_model_collaboratorcommitter">{{ctx.Locale.Tr "repo.settings.trust_model.collaboratorcommitter.long"}}</label>
+							<p class="help">{{ctx.Locale.Tr "repo.settings.trust_model.collaboratorcommitter.desc"}}</p>
+						</div>
+					</div>
+				</div>
+
+				<div class="divider"></div>
+				<div class="field">
+					<button class="ui primary button">{{ctx.Locale.Tr "repo.settings.update_settings"}}</button>
+				</div>
+			</form>
+		</div>
+
+		{{if .IsAdmin}}
+		<h4 class="ui top attached header">
+			{{ctx.Locale.Tr "repo.settings.admin_settings"}}
+		</h4>
+		<div class="ui attached segment">
+			<form class="ui form" method="post">
+				{{.CsrfTokenHtml}}
+				<input type="hidden" name="action" value="admin">
+				<div class="field">
+					<div class="ui checkbox">
+						<input name="enable_health_check" type="checkbox" {{if .Repository.IsFsckEnabled}}checked{{end}}>
+						<label>{{ctx.Locale.Tr "repo.settings.admin_enable_health_check"}}</label>
+					</div>
+				</div>
+
+				<div class="field">
+					<button class="ui primary button">{{ctx.Locale.Tr "repo.settings.update_settings"}}</button>
+				</div>
+			</form>
+
+			<div class="divider"></div>
+			<form class="ui form" method="post">
+				{{.CsrfTokenHtml}}
+				<input type="hidden" name="action" value="admin_index">
+				{{if .IsRepoIndexerEnabled}}
+					<h4 class="ui header">{{ctx.Locale.Tr "repo.settings.admin_code_indexer"}}</h4>
+					<div class="inline fields">
+						<label>{{ctx.Locale.Tr "repo.settings.admin_indexer_commit_sha"}}</label>
+						<span class="field">
+							{{if .CodeIndexerStatus}}
+								<a rel="nofollow" class="ui sha label" href="{{.RepoLink}}/commit/{{.CodeIndexerStatus.CommitSha}}">
+									{{ShortSha .CodeIndexerStatus.CommitSha}}
+								</a>
+							{{else}}
+									<span>{{ctx.Locale.Tr "repo.settings.admin_indexer_unindexed"}}</span>
+							{{end}}
+						</span>
+						<div class="field">
+							<button class="ui primary button" name="request_reindex_type" value="code">{{ctx.Locale.Tr "repo.settings.reindex_button"}}</button>
+						</div>
+					</div>
+				{{end}}
+				<h4 class="ui header">{{ctx.Locale.Tr "repo.settings.admin_stats_indexer"}}</h4>
+				<div class="inline fields">
+					{{if and .StatsIndexerStatus .StatsIndexerStatus.CommitSha}}
+						<label>{{ctx.Locale.Tr "repo.settings.admin_indexer_commit_sha"}}</label>
+					{{end}}
+					<span class="field">
+						{{if and .StatsIndexerStatus .StatsIndexerStatus.CommitSha}}
+							<a rel="nofollow" class="ui sha label" href="{{.RepoLink}}/commit/{{.StatsIndexerStatus.CommitSha}}">
+								{{ShortSha .StatsIndexerStatus.CommitSha}}
+							</a>
+						{{else}}
+							<span>{{ctx.Locale.Tr "repo.settings.admin_indexer_unindexed"}}</span>
+						{{end}}
+					</span>
+					<div class="field">
+						<button class="ui primary button" name="request_reindex_type" value="stats">{{ctx.Locale.Tr "repo.settings.reindex_button"}}</button>
+					</div>
+				</div>
+			</form>
+		</div>
+		{{end}}
+
+		{{if .Permission.IsOwner}}
+		<h4 class="ui top attached error header">
+			{{ctx.Locale.Tr "repo.settings.danger_zone"}}
+		</h4>
+		<div class="ui attached error danger segment">
+			<div class="flex-list">
+				{{if not .Repository.IsFork}}
+					<div class="flex-item tw-items-center">
+						<div class="flex-item-main">
+							<div class="flex-item-title">{{ctx.Locale.Tr "repo.visibility"}}</div>
+							{{if .Repository.IsPrivate}}
+								<div class="flex-item-body">{{ctx.Locale.Tr "repo.settings.visibility.public.text"}}</div>
+							{{else}}
+								<div class="flex-item-body">{{ctx.Locale.Tr "repo.settings.visibility.private.text"}}</div>
+							{{end}}
+						</div>
+						<div class="flex-item-trailing">
+							<button class="ui basic red show-modal button" data-modal="#visibility-repo-modal">
+								{{if .Repository.IsPrivate}}
+									{{ctx.Locale.Tr "repo.settings.visibility.public.button"}}
+								{{else}}
+									{{ctx.Locale.Tr "repo.settings.visibility.private.button"}}
+								{{end}}
+							</button>
+						</div>
+					</div>
+				{{end}}
+				{{if .Repository.IsMirror}}
+					<div class="flex-item">
+						<div class="flex-item-main">
+							<div class="flex-item-title">{{ctx.Locale.Tr "repo.settings.convert"}}</div>
+							<div class="flex-item-body">{{ctx.Locale.Tr "repo.settings.convert_desc"}}</div>
+						</div>
+						<div class="flex-item-trailing">
+							<button class="ui basic red show-modal button" data-modal="#convert-mirror-repo-modal">{{ctx.Locale.Tr "repo.settings.convert"}}</button>
+						</div>
+					</div>
+				{{end}}
+				{{if .CanConvertFork}}
+					<div class="flex-item">
+						<div class="flex-item-main">
+							<div class="flex-item-title">{{ctx.Locale.Tr "repo.settings.convert_fork"}}</div>
+							<div class="flex-item-body">{{ctx.Locale.Tr "repo.settings.convert_fork_desc"}}</div>
+						</div>
+						<div class="flex-item-trailing">
+							<button class="ui basic red show-modal button" data-modal="#convert-fork-repo-modal">{{ctx.Locale.Tr "repo.settings.convert_fork"}}</button>
+						</div>
+					</div>
+				{{end}}
+				<div class="flex-item">
+					<div class="flex-item-main">
+						<div class="flex-item-title">{{ctx.Locale.Tr "repo.settings.transfer"}}</div>
+						<div class="flex-item-body">
+							{{if .RepoTransfer}}
+								{{ctx.Locale.Tr "repo.settings.transfer_started" .RepoTransfer.Recipient.DisplayName}}
+							{{else}}
+								{{ctx.Locale.Tr "repo.settings.transfer_desc"}}
+							{{end}}
+						</div>
+					</div>
+					<div class="flex-item-trailing">
+						{{if .RepoTransfer}}
+							<form class="ui form" action="{{.Link}}" method="post">
+								{{.CsrfTokenHtml}}
+								<input type="hidden" name="action" value="cancel_transfer">
+								<button class="ui red button">{{ctx.Locale.Tr "repo.settings.transfer_abort"}}</button>
+							</form>
+						{{else}}
+							<button class="ui basic red show-modal button" data-modal="#transfer-repo-modal">{{ctx.Locale.Tr "repo.settings.transfer"}}</button>
+						{{end}}
+					</div>
+				</div>
+				{{if .Permission.CanRead ctx.Consts.RepoUnitTypeWiki}}
+					<div class="flex-item">
+						<div class="flex-item-main">
+							<div class="flex-item-title">{{ctx.Locale.Tr "repo.settings.wiki_delete"}}</div>
+							<div class="flex-item-body">{{ctx.Locale.Tr "repo.settings.wiki_delete_desc"}}</div>
+						</div>
+						<div class="flex-item-trailing">
+							<button class="ui basic red show-modal button" data-modal="#delete-wiki-modal">{{ctx.Locale.Tr "repo.settings.wiki_delete"}}</button>
+						</div>
+					</div>
+				{{end}}
+				<div class="flex-item">
+					<div class="flex-item-main">
+						<div class="flex-item-title">{{ctx.Locale.Tr "repo.settings.delete"}}</div>
+						<div class="flex-item-body">{{ctx.Locale.Tr "repo.settings.delete_desc"}}</div>
+					</div>
+					<div class="flex-item-trailing">
+						<button class="ui basic red show-modal button" data-modal="#delete-repo-modal">{{ctx.Locale.Tr "repo.settings.delete"}}</button>
+					</div>
+				</div>
+				{{if not .Repository.IsMirror}}
+					<div class="flex-item tw-items-center">
+						<div class="flex-item-main">
+							{{if .Repository.IsArchived}}
+								<div class="flex-item-title">{{ctx.Locale.Tr "repo.settings.unarchive.header"}}</div>
+								<div class="flex-item-body">{{ctx.Locale.Tr "repo.settings.unarchive.text"}}</div>
+							{{else}}
+								<div class="flex-item-title">{{ctx.Locale.Tr "repo.settings.archive.header"}}</div>
+								<div class="flex-item-body">{{ctx.Locale.Tr "repo.settings.archive.text"}}</div>
+							{{end}}
+						</div>
+						<div class="flex-item-trailing">
+							<button class="ui basic red show-modal button" data-modal="#archive-repo-modal">
+								{{if .Repository.IsArchived}}
+									{{ctx.Locale.Tr "repo.settings.unarchive.button"}}
+								{{else}}
+									{{ctx.Locale.Tr "repo.settings.archive.button"}}
+								{{end}}
+							</button>
+						</div>
+					</div>
+				{{end}}
+			</div>
+		</div>
+		{{end}}
+	</div>
+{{template "repo/settings/layout_footer" .}}
+
+{{if .Permission.IsOwner}}
+	{{if .Repository.IsMirror}}
+		<div class="ui small modal" id="convert-mirror-repo-modal">
+			<div class="header">
+				{{ctx.Locale.Tr "repo.settings.convert"}}
+			</div>
+			<div class="content">
+				<div class="ui warning message">
+					{{ctx.Locale.Tr "repo.settings.convert_notices_1"}}
+				</div>
+				<form class="ui form" action="{{.Link}}" method="post">
+					{{.CsrfTokenHtml}}
+					<input type="hidden" name="action" value="convert">
+					<div class="field">
+						<label>
+							{{ctx.Locale.Tr "repo.settings.transfer_form_title"}}
+							<span class="text red">{{.Repository.Name}}</span>
+						</label>
+					</div>
+					<div class="required field">
+						<label>{{ctx.Locale.Tr "repo.repo_name"}}</label>
+						<input name="repo_name" required maxlength="100">
+					</div>
+
+					<div class="actions">
+						<button class="ui cancel button">{{ctx.Locale.Tr "settings.cancel"}}</button>
+						<button class="ui red button">{{ctx.Locale.Tr "repo.settings.convert_confirm"}}</button>
+					</div>
+				</form>
+			</div>
+		</div>
+	{{end}}
+	{{if .CanConvertFork}}
+		<div class="ui small modal" id="convert-fork-repo-modal">
+			<div class="header">
+				{{ctx.Locale.Tr "repo.settings.convert_fork"}}
+			</div>
+			<div class="content">
+				<div class="ui warning message">
+					{{ctx.Locale.Tr "repo.settings.convert_fork_notices_1"}}
+				</div>
+				<form class="ui form" action="{{.Link}}" method="post">
+					{{.CsrfTokenHtml}}
+					<input type="hidden" name="action" value="convert_fork">
+					<div class="field">
+						<label>
+							{{ctx.Locale.Tr "repo.settings.transfer_form_title"}}
+							<span class="text red">{{.Repository.Name}}</span>
+						</label>
+					</div>
+					<div class="required field">
+						<label>{{ctx.Locale.Tr "repo.repo_name"}}</label>
+						<input name="repo_name" required>
+					</div>
+
+					<div class="actions">
+						<button class="ui cancel button">{{ctx.Locale.Tr "settings.cancel"}}</button>
+						<button class="ui red button">{{ctx.Locale.Tr "repo.settings.convert_fork_confirm"}}</button>
+					</div>
+				</form>
+			</div>
+		</div>
+	{{end}}
+	<div class="ui small modal" id="transfer-repo-modal">
+		<div class="header">
+			{{ctx.Locale.Tr "repo.settings.transfer"}}
+		</div>
+		<div class="content">
+			<div class="ui warning message">
+				{{ctx.Locale.Tr "repo.settings.transfer_notices_1"}} <br>
+				{{ctx.Locale.Tr "repo.settings.transfer_notices_2"}} <br>
+				{{ctx.Locale.Tr "repo.settings.transfer_notices_3"}} <br>
+				{{ctx.Locale.Tr "repo.settings.transfer_notices_4"}}
+			</div>
+			<form class="ui form" action="{{.Link}}" method="post">
+				{{.CsrfTokenHtml}}
+				<input type="hidden" name="action" value="transfer">
+				<div class="field">
+					<label>
+						{{ctx.Locale.Tr "repo.settings.transfer_form_title"}}
+						<span class="text red">{{.Repository.Name}}</span>
+					</label>
+				</div>
+				<div class="required field">
+					<label>{{ctx.Locale.Tr "repo.repo_name"}}</label>
+					<input name="repo_name" required>
+				</div>
+				<div class="required field">
+					<label for="new_owner_name">{{ctx.Locale.Tr "repo.settings.transfer_owner"}}</label>
+					<input id="new_owner_name" name="new_owner_name" required>
+				</div>
+
+				<div class="actions">
+					<button class="ui cancel button">{{ctx.Locale.Tr "settings.cancel"}}</button>
+					<button class="ui red button">{{ctx.Locale.Tr "repo.settings.transfer_perform"}}</button>
+				</div>
+			</form>
+		</div>
+	</div>
+
+	<div class="ui small modal" id="delete-repo-modal">
+		<div class="header">
+			{{ctx.Locale.Tr "repo.settings.delete"}}
+		</div>
+		<div class="content">
+			<div class="ui warning message">
+				{{ctx.Locale.Tr "repo.settings.delete_notices_1"}}<br>
+				{{ctx.Locale.Tr "repo.settings.delete_notices_2" .Repository.FullName}}
+				{{if .Repository.NumForks}}<br>
+				{{ctx.Locale.Tr "repo.settings.delete_notices_fork_1"}}
+				{{end}}
+			</div>
+			<form class="ui form" action="{{.Link}}" method="post">
+				{{.CsrfTokenHtml}}
+				<input type="hidden" name="action" value="delete">
+				<div class="field">
+					<label>
+						{{ctx.Locale.Tr "repo.settings.transfer_form_title"}}
+						<span class="text red">{{.Repository.Name}}</span>
+					</label>
+				</div>
+				<div class="required field">
+					<label for="repo_name_to_delete">{{ctx.Locale.Tr "repo.repo_name"}}</label>
+					<input id="repo_name_to_delete" name="repo_name" required>
+				</div>
+
+				<div class="actions">
+					<button class="ui cancel button">{{ctx.Locale.Tr "settings.cancel"}}</button>
+					<button class="ui red button">{{ctx.Locale.Tr "repo.settings.confirm_delete"}}</button>
+				</div>
+			</form>
+		</div>
+	</div>
+
+	{{if not .Repository.IsFork}}
+		<div class="ui g-modal-confirm modal" id="visibility-repo-modal">
+			<div class="header">
+				{{ctx.Locale.Tr "repo.visibility"}}
+			</div>
+			<div class="content">
+					{{if .Repository.IsPrivate}}
+						<p>{{ctx.Locale.Tr "repo.settings.visibility.public.bullet_title"}}</p>
+						<ul>
+							<li>{{ctx.Locale.Tr "repo.settings.visibility.public.bullet_one"}}</li>
+						</ul>
+					{{else}}
+						<p>{{ctx.Locale.Tr "repo.settings.visibility.private.bullet_title"}}</p>
+						<ul>
+							<li>{{ctx.Locale.Tr "repo.settings.visibility.private.bullet_one"}}</li>
+							<li>{{ctx.Locale.Tr "repo.settings.visibility.private.bullet_two"}}{{if .Repository.NumForks}}<span class="text red">{{ctx.Locale.Tr "repo.visibility_fork_helper"}}</span>{{end}}</li>
+						</ul>
+					{{end}}
+			</div>
+			<form action="{{.Link}}" method="post">
+				{{.CsrfTokenHtml}}
+				<input type="hidden" name="action" value="visibility">
+				<input type="hidden" name="repo_id" value="{{.Repository.ID}}">
+				{{template "base/modal_actions_confirm" .}}
+			</form>
+		</div>
+	{{end}}
+
+	{{if .Repository.UnitEnabled ctx ctx.Consts.RepoUnitTypeWiki}}
+	<div class="ui small modal" id="delete-wiki-modal">
+		<div class="header">
+			{{ctx.Locale.Tr "repo.settings.wiki_delete"}}
+		</div>
+		<div class="content">
+			<div class="ui warning message">
+				{{ctx.Locale.Tr "repo.settings.delete_notices_1"}}<br>
+				{{ctx.Locale.Tr "repo.settings.wiki_delete_notices_1" .Repository.Name}}
+			</div>
+			<form class="ui form" action="{{.Link}}" method="post">
+				{{.CsrfTokenHtml}}
+				<input type="hidden" name="action" value="delete-wiki">
+				<div class="field">
+					<label>
+						{{ctx.Locale.Tr "repo.settings.transfer_form_title"}}
+						<span class="text red">{{.Repository.Name}}</span>
+					</label>
+				</div>
+				<div class="required field">
+					<label>{{ctx.Locale.Tr "repo.repo_name"}}</label>
+					<input name="repo_name" required>
+				</div>
+
+				<div class="actions">
+					<button class="ui cancel button">{{ctx.Locale.Tr "settings.cancel"}}</button>
+					<button class="ui red button">{{ctx.Locale.Tr "repo.settings.confirm_wiki_delete"}}</button>
+				</div>
+			</form>
+		</div>
+	</div>
+	{{end}}
+
+	{{if not .Repository.IsMirror}}
+		<div class="ui g-modal-confirm modal" id="archive-repo-modal">
+			<div class="header">
+				{{if .Repository.IsArchived}}
+					{{ctx.Locale.Tr "repo.settings.unarchive.header"}}
+				{{else}}
+					{{ctx.Locale.Tr "repo.settings.archive.header"}}
+				{{end}}
+			</div>
+			<div class="content">
+				<p>
+					{{if .Repository.IsArchived}}
+						{{ctx.Locale.Tr "repo.settings.unarchive.text"}}
+					{{else}}
+						{{ctx.Locale.Tr "repo.settings.archive.text"}}
+					{{end}}
+				</p>
+			</div>
+			<form action="{{.Link}}" method="post">
+				{{.CsrfTokenHtml}}
+				<input type="hidden" name="action" value="{{if .Repository.IsArchived}}unarchive{{else}}archive{{end}}">
+				<input type="hidden" name="repo_id" value="{{.Repository.ID}}">
+				{{template "base/modal_actions_confirm" .}}
+			</form>
+		</div>
+	{{end}}
+{{end}}
+
+{{template "repo/settings/push_mirror_sync_modal" .}}

--- a/routers/web/repo/issue_view.go
+++ b/routers/web/repo/issue_view.go
@@ -871,7 +871,6 @@ func preparePullViewReviewAndMerge(ctx *context.Context, issue *issues_model.Iss
 						log.Error("IsProtectedBranch: %v", err)
 					} else if !protected {
 						canDelete = true
-						ctx.Data["DeleteBranchLink"] = issue.Link() + "/cleanup"
 					}
 				}
 				canWriteToHeadRepo = true

--- a/routers/web/repo/pull.go
+++ b/routers/web/repo/pull.go
@@ -1972,7 +1972,7 @@ func CleanUpPullRequest(ctx *context.Context) {
 func deleteBranch(ctx *context.Context, pr *issues_model.PullRequest, gitRepo *git.Repository) {
 	if err := repo_service.DeleteBranch(ctx, ctx.Doer, pr.HeadRepo, gitRepo, pr.HeadBranch, pr, nil); err != nil {
 		if !git.IsErrBranchNotExist(err) && !errors.Is(err, repo_service.ErrBranchIsDefault) && !errors.Is(err, git_model.ErrBranchIsProtected) {
-			log.Error("DeleteBranch: %v", err)
+			log.Error("DeleteBranch(%s): %v", pr.HeadBranch, err)
 		}
 		return
 	}

--- a/routers/web/repo/pull.go
+++ b/routers/web/repo/pull.go
@@ -1970,24 +1970,12 @@ func CleanUpPullRequest(ctx *context.Context) {
 }
 
 func deleteBranch(ctx *context.Context, pr *issues_model.PullRequest, gitRepo *git.Repository) {
-	fullBranchName := pr.HeadRepo.FullName() + ":" + pr.HeadBranch
-
 	if err := repo_service.DeleteBranch(ctx, ctx.Doer, pr.HeadRepo, gitRepo, pr.HeadBranch, pr, nil); err != nil {
-		switch {
-		case git.IsErrBranchNotExist(err):
-			ctx.Flash.Error(ctx.Tr("repo.branch.deletion_failed", fullBranchName))
-		case errors.Is(err, repo_service.ErrBranchIsDefault):
-			ctx.Flash.Error(ctx.Tr("repo.branch.deletion_failed", fullBranchName))
-		case errors.Is(err, git_model.ErrBranchIsProtected):
-			ctx.Flash.Error(ctx.Tr("repo.branch.deletion_failed", fullBranchName))
-		default:
+		if !git.IsErrBranchNotExist(err) && !errors.Is(err, repo_service.ErrBranchIsDefault) && !errors.Is(err, git_model.ErrBranchIsProtected) {
 			log.Error("DeleteBranch: %v", err)
-			ctx.Flash.Error(ctx.Tr("repo.branch.deletion_failed", fullBranchName))
 		}
 		return
 	}
-
-	ctx.Flash.Success(ctx.Tr("repo.branch.deletion_success", fullBranchName))
 }
 
 // DownloadPullDiff render a pull's raw diff

--- a/web_src/js/components/PullRequestMergeForm.vue
+++ b/web_src/js/components/PullRequestMergeForm.vue
@@ -136,8 +136,6 @@ function clearMergeMessage() {
       <button class="ui button merge-cancel" @click="toggleActionForm(false)">
         {{ mergeForm.textCancel }}
       </button>
-
-
     </form>
 
     <div v-if="!showActionForm" class="tw-flex">

--- a/web_src/js/components/PullRequestMergeForm.vue
+++ b/web_src/js/components/PullRequestMergeForm.vue
@@ -137,9 +137,7 @@ function clearMergeMessage() {
         {{ mergeForm.textCancel }}
       </button>
 
-      <template v-if="mergeForm.isPullBranchDeletable">
-        <input name="delete_branch_after_merge" type="hidden" value="true">
-      </template>
+
     </form>
 
     <div v-if="!showActionForm" class="tw-flex">


### PR DESCRIPTION
Remove Branch Deletion UI Elements
This plan outlines the steps to resolve issue #179 by removing unnecessary branch-deletion elements from the UI, as branches in Forkana are automatically deleted upon merge.

Proposed Changes
Go Backend

[MODIFY] routers/web/repo/pull.go
In the deleteBranch function, remove the ctx.Flash.Success and ctx.Flash.Error calls so that users do not see the "Branch deleted successfully" alert after merging a change request.
Vue & JS Frontend

[MODIFY] web_src/js/components/PullRequestMergeForm.vue
Remove the delete_branch_after_merge hidden input field which relies on mergeForm.isPullBranchDeletable.


Templates

[MODIFY] custom/templates/repo/issue/view_content/pull_merge_box.tmpl
Remove the "Delete branch" button rendered when a pull request has merged successfully (around line 56).
Remove the "Delete branch" button rendered when a pull request is closed (around line 85).
Remove the textDeleteBranch JavaScript property from the mergeForm configuration block.

[MODIFY] custom/templates/repo/issue/view_content.tmpl
Remove the "repo.branch.delete" confirmation modal (usually located at the bottom of the file).

[OVERRIDE TEMPLATE] custom/templates/repo/settings/options.tmpl
Remove or hide the default_delete_branch_after_merge repository setting from the UI, to prevent confusion.

Co-authored by: Gemini 3.1 pro

Closes [#179](https://github.com/okTurtles/forkana/issues/179)