### PR TITLE
Fix  #175 and  #171: Implement reasonable filesize limits & user-friendly error message

### DIFF
--- a/modules/setting/attachment.go
+++ b/modules/setting/attachment.go
@@ -16,7 +16,7 @@ var Attachment AttachmentSettingType
 func loadAttachmentFrom(rootCfg ConfigProvider) (err error) {
 	Attachment = AttachmentSettingType{
 		AllowedTypes: ".avif,.cpuprofile,.csv,.dmp,.docx,.fodg,.fodp,.fods,.fodt,.gif,.gz,.jpeg,.jpg,.json,.jsonc,.log,.md,.mov,.mp4,.odf,.odg,.odp,.ods,.odt,.patch,.pdf,.png,.pptx,.svg,.tgz,.txt,.webm,.webp,.xls,.xlsx,.zip",
-		MaxSize:      500,
+		MaxSize:      512,
 		MaxFiles:     5,
 		Enabled:      true,
 	}

--- a/modules/setting/attachment.go
+++ b/modules/setting/attachment.go
@@ -16,7 +16,7 @@ var Attachment AttachmentSettingType
 func loadAttachmentFrom(rootCfg ConfigProvider) (err error) {
 	Attachment = AttachmentSettingType{
 		AllowedTypes: ".avif,.cpuprofile,.csv,.dmp,.docx,.fodg,.fodp,.fods,.fodt,.gif,.gz,.jpeg,.jpg,.json,.jsonc,.log,.md,.mov,.mp4,.odf,.odg,.odp,.ods,.odt,.patch,.pdf,.png,.pptx,.svg,.tgz,.txt,.webm,.webp,.xls,.xlsx,.zip",
-		MaxSize:      512,
+		MaxSize:      20,
 		MaxFiles:     5,
 		Enabled:      true,
 	}

--- a/modules/setting/attachment.go
+++ b/modules/setting/attachment.go
@@ -16,7 +16,7 @@ var Attachment AttachmentSettingType
 func loadAttachmentFrom(rootCfg ConfigProvider) (err error) {
 	Attachment = AttachmentSettingType{
 		AllowedTypes: ".avif,.cpuprofile,.csv,.dmp,.docx,.fodg,.fodp,.fods,.fodt,.gif,.gz,.jpeg,.jpg,.json,.jsonc,.log,.md,.mov,.mp4,.odf,.odg,.odp,.ods,.odt,.patch,.pdf,.png,.pptx,.svg,.tgz,.txt,.webm,.webp,.xls,.xlsx,.zip",
-		MaxSize:      2048,
+		MaxSize:      500,
 		MaxFiles:     5,
 		Enabled:      true,
 	}

--- a/routers/api/v1/repo/issue_attachment.go
+++ b/routers/api/v1/repo/issue_attachment.go
@@ -190,6 +190,8 @@ func CreateIssueAttachment(ctx *context.APIContext) {
 	if err != nil {
 		if upload.IsErrFileTypeForbidden(err) {
 			ctx.APIError(http.StatusUnprocessableEntity, err)
+		} else if upload.IsErrFileTooLarge(err) {
+			ctx.APIError(http.StatusRequestEntityTooLarge, err)
 		} else {
 			ctx.APIErrorInternal(err)
 		}

--- a/routers/api/v1/repo/issue_comment_attachment.go
+++ b/routers/api/v1/repo/issue_comment_attachment.go
@@ -199,6 +199,8 @@ func CreateIssueCommentAttachment(ctx *context.APIContext) {
 	if err != nil {
 		if upload.IsErrFileTypeForbidden(err) {
 			ctx.APIError(http.StatusUnprocessableEntity, err)
+		} else if upload.IsErrFileTooLarge(err) {
+			ctx.APIError(http.StatusRequestEntityTooLarge, err)
 		} else {
 			ctx.APIErrorInternal(err)
 		}

--- a/routers/api/v1/repo/release_attachment.go
+++ b/routers/api/v1/repo/release_attachment.go
@@ -245,6 +245,10 @@ func CreateReleaseAttachment(ctx *context.APIContext) {
 			ctx.APIError(http.StatusBadRequest, err)
 			return
 		}
+		if upload.IsErrFileTooLarge(err) {
+			ctx.APIError(http.StatusRequestEntityTooLarge, err)
+			return
+		}
 		ctx.APIErrorInternal(err)
 		return
 	}

--- a/routers/web/repo/attachment.go
+++ b/routers/web/repo/attachment.go
@@ -47,7 +47,7 @@ func uploadAttachment(ctx *context.Context, repoID int64, allowedTypes string) {
 
 	// Validate file size against configured maximum (MaxSize is in MB)
 	if setting.Attachment.MaxSize > 0 && header.Size > setting.Attachment.MaxSize*1024*1024 {
-		ctx.HTTPError(http.StatusBadRequest, fmt.Sprintf("file size exceeds the maximum allowed size of %d MB", setting.Attachment.MaxSize))
+		ctx.HTTPError(http.StatusRequestEntityTooLarge, fmt.Sprintf("file size exceeds the maximum allowed size of %d MB", setting.Attachment.MaxSize))
 		return
 	}
 

--- a/routers/web/repo/attachment.go
+++ b/routers/web/repo/attachment.go
@@ -45,6 +45,12 @@ func uploadAttachment(ctx *context.Context, repoID int64, allowedTypes string) {
 	}
 	defer file.Close()
 
+	// Validate file size against configured maximum (MaxSize is in MB)
+	if setting.Attachment.MaxSize > 0 && header.Size > setting.Attachment.MaxSize*1024*1024 {
+		ctx.HTTPError(http.StatusBadRequest, fmt.Sprintf("file size exceeds the maximum allowed size of %d MB", setting.Attachment.MaxSize))
+		return
+	}
+
 	attach, err := attachment.UploadAttachment(ctx, file, allowedTypes, header.Size, &repo_model.Attachment{
 		Name:       header.Filename,
 		UploaderID: ctx.Doer.ID,

--- a/routers/web/repo/attachment.go
+++ b/routers/web/repo/attachment.go
@@ -45,12 +45,6 @@ func uploadAttachment(ctx *context.Context, repoID int64, allowedTypes string) {
 	}
 	defer file.Close()
 
-	// Validate file size against configured maximum (MaxSize is in MB)
-	if setting.Attachment.MaxSize > 0 && header.Size > setting.Attachment.MaxSize*1024*1024 {
-		ctx.HTTPError(http.StatusRequestEntityTooLarge, fmt.Sprintf("file size exceeds the maximum allowed size of %d MB", setting.Attachment.MaxSize))
-		return
-	}
-
 	attach, err := attachment.UploadAttachment(ctx, file, allowedTypes, header.Size, &repo_model.Attachment{
 		Name:       header.Filename,
 		UploaderID: ctx.Doer.ID,
@@ -59,6 +53,10 @@ func uploadAttachment(ctx *context.Context, repoID int64, allowedTypes string) {
 	if err != nil {
 		if upload.IsErrFileTypeForbidden(err) {
 			ctx.HTTPError(http.StatusBadRequest, err.Error())
+			return
+		}
+		if upload.IsErrFileTooLarge(err) {
+			ctx.HTTPError(http.StatusRequestEntityTooLarge, err.Error())
 			return
 		}
 		ctx.HTTPError(http.StatusInternalServerError, fmt.Sprintf("NewAttachment: %v", err))

--- a/services/attachment/attachment.go
+++ b/services/attachment/attachment.go
@@ -19,6 +19,30 @@ import (
 	"github.com/google/uuid"
 )
 
+// limitedErrorReader wraps a reader and returns ErrFileTooLarge if more than remaining bytes are read.
+// Unlike io.LimitReader, it errors instead of silently stopping, preventing silent file truncation
+// when fileSize is unknown (-1).
+type limitedErrorReader struct {
+	r         io.Reader
+	remaining int64
+	name      string
+	maxMB     int64
+}
+
+func (l *limitedErrorReader) Read(p []byte) (int, error) {
+	// Request one extra byte beyond the limit. If we get it back, the file exceeds the limit.
+	allowRead := l.remaining + 1
+	if int64(len(p)) > allowRead {
+		p = p[:allowRead]
+	}
+	n, err := l.r.Read(p)
+	if int64(n) > l.remaining {
+		return int(l.remaining), upload.ErrFileTooLarge{Name: l.name, MaxMB: l.maxMB}
+	}
+	l.remaining -= int64(n)
+	return n, err
+}
+
 // NewAttachment creates a new attachment object, but do not verify.
 func NewAttachment(ctx context.Context, attach *repo_model.Attachment, file io.Reader, size int64) (*repo_model.Attachment, error) {
 	if attach.RepoID == 0 {
@@ -46,8 +70,9 @@ func UploadAttachment(ctx context.Context, file io.Reader, allowedTypes string, 
 		if fileSize > maxBytes {
 			return nil, upload.ErrFileTooLarge{Name: attach.Name, MaxMB: setting.Attachment.MaxSize}
 		}
-		// Wrap with LimitReader as defense-in-depth against spoofed Content-Length
-		file = io.LimitReader(file, maxBytes)
+		// Wrap with a reader that errors (rather than silently truncates) when the limit is exceeded.
+		// This handles both spoofed Content-Length and unknown size (fileSize == -1).
+		file = &limitedErrorReader{r: file, remaining: maxBytes, name: attach.Name, maxMB: setting.Attachment.MaxSize}
 	}
 
 	buf := make([]byte, 1024)

--- a/services/attachment/attachment.go
+++ b/services/attachment/attachment.go
@@ -11,6 +11,7 @@ import (
 
 	"code.gitea.io/gitea/models/db"
 	repo_model "code.gitea.io/gitea/models/repo"
+	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/storage"
 	"code.gitea.io/gitea/modules/util"
 	"code.gitea.io/gitea/services/context/upload"
@@ -40,6 +41,15 @@ func NewAttachment(ctx context.Context, attach *repo_model.Attachment, file io.R
 
 // UploadAttachment upload new attachment into storage and update database
 func UploadAttachment(ctx context.Context, file io.Reader, allowedTypes string, fileSize int64, attach *repo_model.Attachment) (*repo_model.Attachment, error) {
+	if setting.Attachment.MaxSize > 0 {
+		maxBytes := setting.Attachment.MaxSize << 20
+		if fileSize > maxBytes {
+			return nil, upload.ErrFileTooLarge{Name: attach.Name, MaxMB: setting.Attachment.MaxSize}
+		}
+		// Wrap with LimitReader as defense-in-depth against spoofed Content-Length
+		file = io.LimitReader(file, maxBytes)
+	}
+
 	buf := make([]byte, 1024)
 	n, _ := util.ReadAtMost(file, buf)
 	buf = buf[:n]

--- a/services/context/upload/upload.go
+++ b/services/context/upload/upload.go
@@ -4,6 +4,7 @@
 package upload
 
 import (
+	"fmt"
 	"mime"
 	"net/http"
 	"net/url"
@@ -17,6 +18,22 @@ import (
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/services/context"
 )
+
+// ErrFileTooLarge file exceeds the configured maximum upload size
+type ErrFileTooLarge struct {
+	Name  string
+	MaxMB int64
+}
+
+// IsErrFileTooLarge checks if an error is ErrFileTooLarge.
+func IsErrFileTooLarge(err error) bool {
+	_, ok := err.(ErrFileTooLarge)
+	return ok
+}
+
+func (err ErrFileTooLarge) Error() string {
+	return fmt.Sprintf("file size exceeds the maximum allowed size of %d MB", err.MaxMB)
+}
 
 // ErrFileTypeForbidden not allowed file type error
 type ErrFileTypeForbidden struct {

--- a/services/mailer/incoming/incoming_handler.go
+++ b/services/mailer/incoming/incoming_handler.go
@@ -95,6 +95,10 @@ func (h *ReplyHandler) Handle(ctx context.Context, content *MailContent, doer *u
 					log.Info("Skipping disallowed attachment type: %s", attachment.Name)
 					continue
 				}
+				if upload.IsErrFileTooLarge(err) {
+					log.Info("Skipping oversized attachment: %s", attachment.Name)
+					continue
+				}
 				return err
 			}
 			attachmentIDs = append(attachmentIDs, a.UUID)

--- a/web_src/js/features/dropzone.ts
+++ b/web_src/js/features/dropzone.ts
@@ -89,9 +89,25 @@ export async function initDropzone(dropzoneEl: HTMLElement) {
   if (dropzoneEl.hasAttribute('data-max-file')) opts.maxFiles = Number(dropzoneEl.getAttribute('data-max-file'));
   if (dropzoneEl.hasAttribute('data-max-size')) opts.maxFilesize = Number(dropzoneEl.getAttribute('data-max-size'));
 
-  // there is a bug in dropzone: if a non-image file is uploaded, then it tries to request the file from server by something like:
-  // "http://localhost:3000/owner/repo/issues/[object%20Event]"
-  // the reason is that the preview "callback(dataURL)" is assign to "img.onerror" then "thumbnail" uses the error object as the dataURL and generates '<img src="[object Event]">'
+  // There is a bug in Dropzone: when a non-image file is uploaded, the thumbnail generation
+  // creates an <img> with onerror=callback. When the image fails to load, the Error event object
+  // is passed as the "dataURL", producing '<img src="[object Event]">'. Browsers (especially Brave)
+  // then try to navigate/download that broken URL instead of uploading the file.
+  // Fix: intercept the thumbnail and replace invalid dataURLs with a transparent pixel.
+  const transparentPixel = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+  opts.thumbnail = (file: any, dataURL: string) => {
+    if (dataURL && !dataURL.startsWith('data:') && !dataURL.startsWith('http:') && !dataURL.startsWith('https:')) {
+      dataURL = transparentPixel;
+    }
+    // Apply the thumbnail to the preview element (Dropzone's default behavior)
+    if (file.previewElement) {
+      file.previewElement.classList.remove('dz-file-preview');
+      for (const thumbnailElement of file.previewElement.querySelectorAll('[data-dz-thumbnail]')) {
+        thumbnailElement.alt = file.name;
+        thumbnailElement.src = dataURL;
+      }
+    }
+  };
   const dzInst = await createDropzone(dropzoneEl, opts);
   dzInst.on('success', (file: CustomDropzoneFile, resp: any) => {
     file.uuid = resp.uuid;

--- a/web_src/js/features/dropzone.ts
+++ b/web_src/js/features/dropzone.ts
@@ -95,7 +95,7 @@ export async function initDropzone(dropzoneEl: HTMLElement) {
   // then try to navigate/download that broken URL instead of uploading the file.
   // Fix: intercept the thumbnail and replace invalid dataURLs with a transparent pixel.
   const transparentPixel = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
-  opts.thumbnail = (file: any, dataURL: unknown) => {
+  opts.thumbnail = (file: DropzoneFile, dataURL: unknown) => {
     const thumbnailURL = typeof dataURL === 'string' && (
       dataURL.startsWith('data:') ||
       dataURL.startsWith('http:') ||

--- a/web_src/js/features/dropzone.ts
+++ b/web_src/js/features/dropzone.ts
@@ -95,16 +95,21 @@ export async function initDropzone(dropzoneEl: HTMLElement) {
   // then try to navigate/download that broken URL instead of uploading the file.
   // Fix: intercept the thumbnail and replace invalid dataURLs with a transparent pixel.
   const transparentPixel = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
-  opts.thumbnail = (file: any, dataURL: string) => {
-    if (dataURL && !dataURL.startsWith('data:') && !dataURL.startsWith('http:') && !dataURL.startsWith('https:')) {
-      dataURL = transparentPixel;
-    }
+  opts.thumbnail = (file: any, dataURL: unknown) => {
+    const thumbnailURL = typeof dataURL === 'string' && (
+      dataURL.startsWith('data:') ||
+      dataURL.startsWith('http:') ||
+      dataURL.startsWith('https:') ||
+      dataURL.startsWith('blob:') ||
+      dataURL.startsWith('/')
+    ) ? dataURL : transparentPixel;
     // Apply the thumbnail to the preview element (Dropzone's default behavior)
     if (file.previewElement) {
       file.previewElement.classList.remove('dz-file-preview');
+      file.previewElement.classList.add('dz-image-preview');
       for (const thumbnailElement of file.previewElement.querySelectorAll('[data-dz-thumbnail]')) {
         thumbnailElement.alt = file.name;
-        thumbnailElement.src = dataURL;
+        thumbnailElement.src = thumbnailURL;
       }
     }
   };

--- a/web_src/js/features/dropzone.ts
+++ b/web_src/js/features/dropzone.ts
@@ -107,7 +107,7 @@ export async function initDropzone(dropzoneEl: HTMLElement) {
     if (file.previewElement) {
       file.previewElement.classList.remove('dz-file-preview');
       file.previewElement.classList.add('dz-image-preview');
-      for (const thumbnailElement of file.previewElement.querySelectorAll('[data-dz-thumbnail]')) {
+      for (const thumbnailElement of file.previewElement.querySelectorAll<HTMLImageElement>('[data-dz-thumbnail]')) {
         thumbnailElement.alt = file.name;
         thumbnailElement.src = thumbnailURL;
       }


### PR DESCRIPTION
Two related bugs around file attachments in Forkana's comment/issue dropzone:

#171 – Non-image large file triggers download: When a large non-image file (e.g. >22MB) is dragged into the dropzone in Brave, instead of uploading, it triggers a browser download dialog. This is a known Dropzone.js bug where the thumbnail preview for non-image files creates an <img> element with onerror set to the callback, which fires with an Event object as the "dataURL", generating `<img src="[object Event]">`. The browser then tries to navigate/download that URL.
#175 – No file size limit enforcement: When uploading a file that exceeds the configured MAX_SIZE (default 2048 MB), the server responds with a 500 error ("rendered content too large"), there's no user-friendly warning, and the attachment can't be deleted.

Proposed changes for this PR:

1. Fix non-image thumbnail handling
    * Update dropzone.ts.
    * Prevent Dropzone from using invalid thumbnail URLs for non-image files.
    * Validate the thumbnail dataURL before applying it.
    * If the thumbnail value is invalid, replace it with a transparent placeholder instead of letting the browser try to load/download it.
2. Add server-side file size validation
    * Update attachment.go.
    * In uploadAttachment(), check header.Size against setting.Attachment.MaxSize.
    * If the file is too large, return 400 Bad Request with a clear error instead of allowing the upload to continue and potentially fail with a 500.
    
3. Keep client-side validation as-is
    * Dropzone already receives data-max-size in MB.
    * The existing maxFilesize + dictFileTooBig handling should already show a clear message before upload.
    * The server-side check is added as a fallback in case client-side validation is bypassed.
 
Co-authored by: Claude Opus 4.6

Closes https://github.com/okTurtles/forkana/issues/175 and https://github.com/okTurtles/forkana/issues/171