### PR TITLE
Add dual-mode (standalone | forums) deploy axis to forkana

### DIFF
--- a/docker/forkana/DEPLOYMENT_GUIDE.md
+++ b/docker/forkana/DEPLOYMENT_GUIDE.md
@@ -4,15 +4,67 @@ This guide covers deploying Forkana to a single Linux VM for private dev instanc
 
 ## Table of Contents
 
-1. [Prerequisites](#prerequisites)
-2. [Server Preparation](#server-preparation)
-3. [Server Setup (CI/CD)](#server-setup-cicd)
-4. [Environment Configuration](#environment-configuration)
-5. [Running Forkana](#running-forkana)
-6. [Reverse Proxy Setup](#reverse-proxy-setup)
-7. [Health Checks & Verification](#health-checks--verification)
-8. [Troubleshooting](#troubleshooting)
-9. [Maintenance](#maintenance)
+1. [Deployment mode](#deployment-mode)
+2. [Prerequisites](#prerequisites)
+3. [Server Preparation](#server-preparation)
+4. [Server Setup (CI/CD)](#server-setup-cicd)
+5. [Environment Configuration](#environment-configuration)
+6. [Running Forkana](#running-forkana)
+7. [Reverse Proxy Setup](#reverse-proxy-setup)
+8. [Health Checks & Verification](#health-checks--verification)
+9. [Troubleshooting](#troubleshooting)
+10. [Maintenance](#maintenance)
+
+---
+
+## Deployment mode
+
+`docker/forkana/deploy_common.sh` supports two deployment layouts, selected at
+run time per host:
+
+- **`standalone`** *(default)* - Forkana owns its compose project on a
+  dedicated VM. The pipeline brings up its own `registry`, `postgres`, and
+  `forkana` services from `docker/forkana/dev.yml` under project name
+  `forkana`. **All instructions in the rest of this guide describe this
+  mode** and continue to work unchanged.
+- **`forums`** - Forkana joins an existing external Compose project as a
+  sibling service. The pipeline reuses that project's `postgres` instance
+  and a host-managed registry, and only writes a digest-pinned override
+  file under the external stack's working tree. The external-stack
+  contract (service block, database bootstrap, secrets layout) is owned
+  and documented by that stack itself.
+
+The mode is resolved by sourcing `~/forkana/deploy.conf` at the start of
+each deploy. **Absence of the file selects `standalone`** - existing
+standalone hosts need no action.
+
+To opt a host into forums mode, create `~/forkana/deploy.conf` with
+permissions `600` and the deploy user as owner:
+
+```bash
+# ~/forkana/deploy.conf - required for forums mode, optional for standalone.
+FORKANA_DEPLOY_MODE=forums              # standalone | forums
+FORUMS_DIR=/path/to/stack               # required iff mode=forums; absolute path
+                                        # to the external Compose project root.
+
+# Optional knobs (defaults are layout-agnostic; relative paths resolve
+# against ${FORUMS_DIR}):
+# FORUMS_ENV_FILE=.env                  # env file passed to docker compose
+# FORUMS_OVERRIDE_FILE=forkana-override.yml  # digest-pinned override path
+# FORUMS_EXTRA_COMPOSE_FILES=""         # whitespace-separated extra -f files
+```
+
+`FORUMS_ENV_FILE` must be provisioned by the external stack with
+`POSTGRES_FORKANA_PASSWORD`, `FORKANA_DOMAIN`, `FORKANA_ROOT_URL`,
+`FORKANA_SECRET_KEY`, `FORKANA_INTERNAL_TOKEN`, `FORKANA_JWT_SECRET`,
+and `FORKANA_HOST_PORT` (typically a non-3000 port to avoid collisions
+with sibling services). These variable names form the integration
+contract with the external stack.
+
+The remainder of this guide covers **standalone** setup. Forums-mode
+host bootstrap (creating the deploy user, provisioning the env file,
+initialising the shared database, and starting the registry) is handled
+by the external stack's own documentation.
 
 ---
 
@@ -723,7 +775,7 @@ docker compose --env-file ~/forkana/compose/.env \
 ```
 
 ```bash
-# Verify permissions (run as root — ~/forkana would expand to /root)
+# Verify permissions (run as root - ~/forkana would expand to /root)
 DEPLOY_USER="forkana-deploy"  # replace with your UID 1000 username
 DEPLOY_HOME="$(getent passwd "${DEPLOY_USER}" | cut -d: -f6)"
 

--- a/docker/forkana/deploy_common.sh
+++ b/docker/forkana/deploy_common.sh
@@ -59,23 +59,87 @@ deploy_init() {
   else
     REPO_DIR="${DEPLOY_DIR}/repo"
   fi
-  COMPOSE_DIR="${DEPLOY_DIR}/compose"
+
+  # --- Deploy mode resolution ---
+  # Default to standalone for backward compatibility; forums hosts opt in by
+  # writing ${DEPLOY_DIR}/deploy.conf.  See DEPLOYMENT_GUIDE.md
+  # § "Deployment mode".
+  FORKANA_DEPLOY_MODE="${FORKANA_DEPLOY_MODE:-standalone}"
+  if [[ -f "${DEPLOY_DIR}/deploy.conf" ]]; then
+    # shellcheck source=/dev/null
+    . "${DEPLOY_DIR}/deploy.conf"
+  fi
+
   REGISTRY_PORT="${REGISTRY_PORT:-5000}"
   REGISTRY="localhost:${REGISTRY_PORT}"
   # Use explicit IPv4 for curl checks - avoids IPv6 resolution issues on hosts
   # where "localhost" may resolve to ::1 before 127.0.0.1.
   REGISTRY_HTTP="http://127.0.0.1:${REGISTRY_PORT}"
   IMAGE_NAME="forkana"
-  PROJECT_NAME="forkana"
-  COMPOSE_BASE="${COMPOSE_DIR}/dev.yml"
-  COMPOSE_OVERRIDE="${COMPOSE_DIR}/compose.override.yml"
-  ENV_FILE="${COMPOSE_DIR}/.env"
+
+  case "${FORKANA_DEPLOY_MODE}" in
+    standalone)
+      PROJECT_NAME="forkana"
+      COMPOSE_DIR="${DEPLOY_DIR}/compose"
+      COMPOSE_BASE="${COMPOSE_DIR}/dev.yml"
+      COMPOSE_OVERRIDE="${COMPOSE_DIR}/compose.override.yml"
+      COMPOSE_FILES=( -f "${COMPOSE_BASE}" -f "${COMPOSE_OVERRIDE}" )
+      COMPOSE_PROJECT_DIRECTORY="${COMPOSE_DIR}"
+      ENV_FILE="${COMPOSE_DIR}/.env"
+      SNAPSHOT_DIR="${COMPOSE_DIR}"
+      MANAGE_REGISTRY=1
+      MANAGE_DATA_DIRS=1
+      REQUIRED_VARS=(POSTGRES_PASSWORD FORKANA_DOMAIN FORKANA_SECRET_KEY \
+                     FORKANA_INTERNAL_TOKEN FORKANA_JWT_SECRET)
+      ;;
+    forums)
+      [[ -n "${FORUMS_DIR:-}" ]] || die "FORUMS_DIR not set in ${DEPLOY_DIR}/deploy.conf (required when FORKANA_DEPLOY_MODE=forums)."
+      [[ -d "${FORUMS_DIR}"   ]] || die "FORUMS_DIR does not exist: ${FORUMS_DIR}"
+      # Operator-overridable knobs; defaults are layout-agnostic so the
+      # public code does not bake in any specific external-stack layout.
+      # Relative paths resolve against ${FORUMS_DIR}.  See
+      # DEPLOYMENT_GUIDE.md § "Deployment mode" for the recognised
+      # variables.
+      FORUMS_ENV_FILE="${FORUMS_ENV_FILE:-${FORUMS_DIR}/.env}"
+      [[ "${FORUMS_ENV_FILE}" = /* ]] || FORUMS_ENV_FILE="${FORUMS_DIR}/${FORUMS_ENV_FILE}"
+      FORUMS_OVERRIDE_FILE="${FORUMS_OVERRIDE_FILE:-${FORUMS_DIR}/forkana-override.yml}"
+      [[ "${FORUMS_OVERRIDE_FILE}" = /* ]] || FORUMS_OVERRIDE_FILE="${FORUMS_DIR}/${FORUMS_OVERRIDE_FILE}"
+      PROJECT_NAME="forums"
+      COMPOSE_DIR="${FORUMS_DIR}"
+      COMPOSE_BASE="${FORUMS_DIR}/docker-compose.yml"
+      COMPOSE_OVERRIDE="${FORUMS_OVERRIDE_FILE}"
+      COMPOSE_FILES=( -f "${COMPOSE_BASE}" )
+      # Optional whitespace-separated list of extra compose files to layer
+      # before the digest-pinned override (e.g. a sibling-services file
+      # provided by the external stack).  Relative entries resolve against
+      # ${FORUMS_DIR}.
+      if [[ -n "${FORUMS_EXTRA_COMPOSE_FILES:-}" ]]; then
+        local _extra
+        for _extra in ${FORUMS_EXTRA_COMPOSE_FILES}; do
+          [[ "${_extra}" = /* ]] || _extra="${FORUMS_DIR}/${_extra}"
+          COMPOSE_FILES+=( -f "${_extra}" )
+        done
+      fi
+      COMPOSE_FILES+=( -f "${COMPOSE_OVERRIDE}" )
+      COMPOSE_PROJECT_DIRECTORY="${FORUMS_DIR}"
+      ENV_FILE="${FORUMS_ENV_FILE}"
+      SNAPSHOT_DIR="${DEPLOY_DIR}/snapshots"
+      MANAGE_REGISTRY=0
+      MANAGE_DATA_DIRS=0
+      REQUIRED_VARS=(POSTGRES_FORKANA_PASSWORD FORKANA_DOMAIN FORKANA_ROOT_URL \
+                     FORKANA_SECRET_KEY FORKANA_INTERNAL_TOKEN FORKANA_JWT_SECRET \
+                     FORKANA_HOST_PORT)
+      ;;
+    *)
+      die "Unknown FORKANA_DEPLOY_MODE: '${FORKANA_DEPLOY_MODE}' (expected: standalone | forums)."
+      ;;
+  esac
 
   # Resolve HOST_PORT for the health-check probe.  Prefer the exported shell
   # variable; otherwise read FORKANA_HOST_PORT from ${ENV_FILE} so the probe
-  # targets the same port Compose binds via dev.yml interpolation.  Without
-  # this, setting FORKANA_HOST_PORT only in .env (as documented) caused every
-  # deploy to fail health-check and roll back.
+  # targets the same port Compose binds via interpolation.  Without this,
+  # setting FORKANA_HOST_PORT only in the env file (as documented) caused
+  # every deploy to fail health-check and roll back.
   HOST_PORT="${FORKANA_HOST_PORT:-3000}"
   if [[ -z "${FORKANA_HOST_PORT:-}" ]]; then
     local env_port
@@ -129,56 +193,74 @@ deploy_run() {
   fi
 
   # --- Step 1: Prepare compose directory and base file ---
-  mkdir -p "${COMPOSE_DIR}"
-  if [[ -f "${REPO_DIR}/docker/forkana/dev.yml" ]]; then
-    cp "${REPO_DIR}/docker/forkana/dev.yml" "${COMPOSE_BASE}"
-    log "Copied dev.yml to ${COMPOSE_BASE}"
-  else
-    if [[ ! -f "${COMPOSE_BASE}" ]]; then
-      die "Missing ${COMPOSE_BASE} - ensure dev.yml is deployed to ${COMPOSE_DIR}"
+  # Standalone owns the compose layout under ${COMPOSE_DIR}.  In forums mode
+  # the compose files live inside ${FORUMS_DIR} and are managed by the forums
+  # framework; we only rewrite ${COMPOSE_OVERRIDE} (step 7).
+  if (( MANAGE_DATA_DIRS )); then
+    mkdir -p "${COMPOSE_DIR}"
+    if [[ -f "${REPO_DIR}/docker/forkana/dev.yml" ]]; then
+      cp "${REPO_DIR}/docker/forkana/dev.yml" "${COMPOSE_BASE}"
+      log "Copied dev.yml to ${COMPOSE_BASE}"
+    else
+      if [[ ! -f "${COMPOSE_BASE}" ]]; then
+        die "Missing ${COMPOSE_BASE} - ensure dev.yml is deployed to ${COMPOSE_DIR}"
+      fi
+      log "Using pre-deployed dev.yml at ${COMPOSE_BASE}"
     fi
-    log "Using pre-deployed dev.yml at ${COMPOSE_BASE}"
-  fi
 
-  printf 'services:\n  forkana:\n    image: %s/forkana:latest\n' "${REGISTRY}" \
-    > "${COMPOSE_OVERRIDE}"
-  log "Wrote placeholder ${COMPOSE_OVERRIDE}"
+    printf 'services:\n  forkana:\n    image: %s/forkana:latest\n' "${REGISTRY}" \
+      > "${COMPOSE_OVERRIDE}"
+    log "Wrote placeholder ${COMPOSE_OVERRIDE}"
+  else
+    # Forums mode: compose layout owned by the external stack.  Verify
+    # every -f file we will pass to docker compose exists before any
+    # invocation; the digest-pinned override is created below, so skip it.
+    local _i _f
+    for ((_i = 0; _i < ${#COMPOSE_FILES[@]}; _i++)); do
+      [[ "${COMPOSE_FILES[_i]}" == "-f" ]] || continue
+      _f="${COMPOSE_FILES[_i + 1]}"
+      [[ "${_f}" == "${COMPOSE_OVERRIDE}" ]] && continue
+      [[ -f "${_f}" ]] || die "Missing compose file: ${_f} - the external stack must provide it (see deploy.conf knobs FORUMS_EXTRA_COMPOSE_FILES)."
+    done
+    mkdir -p "$(dirname "${COMPOSE_OVERRIDE}")"
+  fi
 
   # --- Step 1b: Ensure host volume directories exist with correct ownership ---
   # Only chmod when we create the directory: once a container (postgres initdb,
   # gitea entrypoint) has taken ownership of its bind-mounted data dir, a later
   # chmod by the deploying user would return EPERM and break subsequent
-  # redeploys.
-  log "Ensuring volume directories exist with correct ownership..."
-  for dir in \
-    "${DEPLOY_DIR}/data" \
-    "${DEPLOY_DIR}/data/git" \
-    "${DEPLOY_DIR}/data/custom" \
-    "${DEPLOY_DIR}/config" \
-    "${DEPLOY_DIR}/postgres"; do
-    if [[ ! -d "${dir}" ]]; then
-      mkdir -p "${dir}"
-      chmod 0755 "${dir}"
-    fi
-  done
-
-  # --- Step 1c: Verify .env exists before any docker compose invocation ---
-  # This must happen before Step 2 (registry startup) because dev.yml interpolates
-  # environment variables like ${POSTGRES_PASSWORD}. If .env is missing, docker compose
-  # will fail with a confusing error. Validate early to give users a clear message.
-  # ENV_FILE is set in deploy_init so HOST_PORT can be resolved from it.
-  if [[ ! -f "${ENV_FILE}" ]]; then
-    die "Missing ${ENV_FILE} - create it with POSTGRES_PASSWORD, FORKANA_DOMAIN, FORKANA_SECRET_KEY, FORKANA_INTERNAL_TOKEN, and FORKANA_JWT_SECRET (see DEPLOYMENT_GUIDE.md)."
+  # redeploys.  Forums mode skips this entirely: bind-mount roots for the
+  # forkana service are bootstrapped once by the operator with chown 1000:1000.
+  if (( MANAGE_DATA_DIRS )); then
+    log "Ensuring volume directories exist with correct ownership..."
+    for dir in \
+      "${DEPLOY_DIR}/data" \
+      "${DEPLOY_DIR}/data/git" \
+      "${DEPLOY_DIR}/data/custom" \
+      "${DEPLOY_DIR}/config" \
+      "${DEPLOY_DIR}/postgres"; do
+      if [[ ! -d "${dir}" ]]; then
+        mkdir -p "${dir}"
+        chmod 0755 "${dir}"
+      fi
+    done
   fi
 
-  local required_vars=(POSTGRES_PASSWORD FORKANA_DOMAIN FORKANA_SECRET_KEY FORKANA_INTERNAL_TOKEN FORKANA_JWT_SECRET)
-  local missing=()
+  # --- Step 1c: Verify env file exists and required vars are populated ---
+  # This must happen before Step 2 (registry startup) because the compose
+  # files interpolate variables like ${POSTGRES_PASSWORD}.  Validate early
+  # to give a clear error message instead of a confusing compose failure.
+  # REQUIRED_VARS is mode-specific and set in deploy_init.
+  if [[ ! -f "${ENV_FILE}" ]]; then
+    die "Missing ${ENV_FILE} - create it with: ${REQUIRED_VARS[*]} (see DEPLOYMENT_GUIDE.md)."
+  fi
 
+  local missing=()
   # Parse each value through read_env_var so empty quoted forms (FOO="",
   # FOO='') and surrounding whitespace are caught; a bare "[^space#]+" grep
   # would treat a lone quote as a valid value and let an empty secret reach
   # the container.
-  for var in "${required_vars[@]}"; do
+  for var in "${REQUIRED_VARS[@]}"; do
     local val
     val="$(read_env_var "${ENV_FILE}" "${var}")"
     if [[ -z "${val}" ]]; then
@@ -192,21 +274,20 @@ deploy_run() {
 
   # --- Step 2: Ensure the local registry is running ---
   # The registry on 127.0.0.1:${REGISTRY_PORT} may be shared infrastructure
-  # (not owned by Forkana).  Reuse it if already reachable; only start the
-  # compose-managed registry if nothing is listening.
+  # (not owned by Forkana).  In standalone mode, start a compose-managed
+  # registry as a fallback when nothing is listening.  In forums mode the
+  # registry is always external (managed by the surrounding stack outside
+  # this compose project); we only pre-flight that it is reachable.
   log "Ensuring local registry is running..."
   if curl -sf "${REGISTRY_HTTP}/v2/" > /dev/null 2>&1; then
-    # Something is already listening - treat as external/shared and do not
-    # try to (re)create our compose-managed registry in step 8.
     log "Registry already reachable at ${REGISTRY_HTTP} - reusing it."
     REGISTRY_MANAGED_BY_US=false
-  else
+  elif (( MANAGE_REGISTRY )); then
     log "No registry on ${REGISTRY_HTTP} - starting compose-managed registry..."
     docker compose \
       -p "${PROJECT_NAME}" \
-      --project-directory "${COMPOSE_DIR}" \
-      -f "${COMPOSE_BASE}" \
-      -f "${COMPOSE_OVERRIDE}" \
+      --project-directory "${COMPOSE_PROJECT_DIRECTORY}" \
+      "${COMPOSE_FILES[@]}" \
       up -d registry
     REGISTRY_MANAGED_BY_US=true
 
@@ -219,6 +300,8 @@ deploy_run() {
       log "  attempt ${i}/12 - registry not ready yet"
       sleep 5
     done
+  else
+    die "External registry not reachable at ${REGISTRY_HTTP} - start the registry on the host before deploying."
   fi
   log "Registry is ready at ${REGISTRY}."
 
@@ -280,13 +363,17 @@ deploy_run() {
   log "Resolved digest: ${DIGEST}"
   log "Pinned image ref: ${PINNED_REF}"
 
-  # --- Step 7: Generate compose.override.yml (digest-pinned) ---
+  # --- Step 7: Generate the digest-pinned override file ---
   # Snapshot the current override so step 9 can restore it on failure.
-  # On a first deploy the snapshot is the placeholder written in step 1;
-  # on subsequent deploys it is the previous pinned digest.
+  # On a first deploy the snapshot is the placeholder written in step 1
+  # (standalone) or absent (forums); on subsequent deploys it is the
+  # previous pinned digest.  In forums mode the snapshot lives under
+  # ${SNAPSHOT_DIR} (off the forums working tree) so the rollback artefact
+  # never pollutes the shared checkout.
+  mkdir -p "${SNAPSHOT_DIR}"
   PREV_OVERRIDE=""
   if [[ -f "${COMPOSE_OVERRIDE}" ]]; then
-    PREV_OVERRIDE="${COMPOSE_OVERRIDE}.prev"
+    PREV_OVERRIDE="${SNAPSHOT_DIR}/$(basename "${COMPOSE_OVERRIDE}").prev"
     cp -f "${COMPOSE_OVERRIDE}" "${PREV_OVERRIDE}"
   fi
   printf 'services:\n  forkana:\n    image: %s\n' "${PINNED_REF}" \
@@ -294,20 +381,28 @@ deploy_run() {
   log "Wrote ${COMPOSE_OVERRIDE}"
 
   # --- Step 8: Deploy with docker compose ---
-  # Select services explicitly so we do not try to (re)bind port
-  # ${REGISTRY_PORT} when the registry is external/shared.  --remove-orphans
-  # is intentionally omitted here: compose would otherwise interpret unlisted
-  # services (the registry, when external) as "orphans" and stop them.
+  # Select services explicitly so we do not try to (re)bind shared host
+  # ports owned by sibling services.  --remove-orphans is intentionally
+  # omitted: compose would otherwise classify any unlisted service (the
+  # external registry in standalone, or every other forums service in
+  # forums mode) as an "orphan" and stop it.
   log "Running docker compose up..."
-  local compose_services=(postgres forkana)
-  if [[ "${REGISTRY_MANAGED_BY_US}" == "true" ]]; then
-    compose_services=(registry postgres forkana)
+  local compose_services
+  if (( MANAGE_DATA_DIRS )); then
+    # Standalone: bring up the full forkana project on a dedicated host.
+    compose_services=(postgres forkana)
+    if [[ "${REGISTRY_MANAGED_BY_US}" == "true" ]]; then
+      compose_services=(registry postgres forkana)
+    fi
+  else
+    # Forums mode: only recreate forkana; siblings (postgres, nginx, ...)
+    # are owned by the forums stack and must not be touched here.
+    compose_services=(forkana)
   fi
   docker compose \
     -p "${PROJECT_NAME}" \
-    --project-directory "${COMPOSE_DIR}" \
-    -f "${COMPOSE_BASE}" \
-    -f "${COMPOSE_OVERRIDE}" \
+    --project-directory "${COMPOSE_PROJECT_DIRECTORY}" \
+    "${COMPOSE_FILES[@]}" \
     up -d "${compose_services[@]}"
 
   # --- Step 9: Health check ---
@@ -330,21 +425,19 @@ deploy_run() {
 
   docker compose \
     -p "${PROJECT_NAME}" \
-    --project-directory "${COMPOSE_DIR}" \
-    -f "${COMPOSE_BASE}" \
-    -f "${COMPOSE_OVERRIDE}" \
+    --project-directory "${COMPOSE_PROJECT_DIRECTORY}" \
+    "${COMPOSE_FILES[@]}" \
     logs --tail=100 forkana || true
 
   if [[ -n "${PREV_OVERRIDE}" && -f "${PREV_OVERRIDE}" ]]; then
     log "Rolling back to previous pinned image from ${PREV_OVERRIDE}..."
     mv -f "${PREV_OVERRIDE}" "${COMPOSE_OVERRIDE}"
-    # Re-run compose on forkana only; postgres/registry are already healthy
-    # and do not need to be recreated.
+    # Re-run compose on forkana only; siblings are already healthy and
+    # do not need to be recreated.
     if docker compose \
          -p "${PROJECT_NAME}" \
-         --project-directory "${COMPOSE_DIR}" \
-         -f "${COMPOSE_BASE}" \
-         -f "${COMPOSE_OVERRIDE}" \
+         --project-directory "${COMPOSE_PROJECT_DIRECTORY}" \
+         "${COMPOSE_FILES[@]}" \
          up -d forkana; then
       log "Rollback complete - previous image is active again."
     else

--- a/docker/forkana/dev.yml
+++ b/docker/forkana/dev.yml
@@ -1,3 +1,7 @@
+# Standalone compose entry point for Forkana (FORKANA_DEPLOY_MODE=standalone).
+# Forums-mode deployments use the external stack's own docker-compose.yml
+# layered with a digest-pinned override file instead; see
+# DEPLOYMENT_GUIDE.md § "Deployment mode".
 name: forkana
 
 services:

--- a/docker/forkana/tests/deploy_common.test.sh
+++ b/docker/forkana/tests/deploy_common.test.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# deploy_common.test.sh - Focused tests for deploy_common.sh::deploy_init.
+#
+# Sources the script in subshells, redirects HOME to a temp dir, and asserts
+# the mode-resolution contract (PROJECT_NAME, COMPOSE_FILES, REQUIRED_VARS,
+# ENV_FILE, MANAGE_*) for both standalone (no deploy.conf) and forums (with
+# fixture deploy.conf).  Stubs out network-touching commands.
+#
+# Run from the repo root:
+#   bash docker/forkana/tests/deploy_common.test.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMMON="${SCRIPT_DIR}/../deploy_common.sh"
+[[ -f "${COMMON}" ]] || { echo "FATAL: cannot locate ${COMMON}" >&2; exit 2; }
+
+PASS=0
+FAIL=0
+FAILED_TESTS=()
+
+# -----------------------------------------------------------------------------
+# Test helpers
+# -----------------------------------------------------------------------------
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "${expected}" == "${actual}" ]]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    FAILED_TESTS+=("${label}: expected '${expected}', got '${actual}'")
+  fi
+}
+
+# Run deploy_init in a clean subshell and emit `KEY=VALUE` lines for the
+# variables under test on stdout.  `git`, `docker`, `curl` are not invoked by
+# deploy_init itself; `git rev-parse` is the only external call and it is
+# tolerant of failure (`|| true`).  We override PATH to make this explicit.
+run_init() {
+  local home_dir="$1"
+  (
+    HOME="${home_dir}"
+    export HOME
+    # Hide the host repo so LOCAL_REPO_ROOT does not point at the forkana
+    # checkout running this test - keeps REPO_DIR deterministic.
+    cd "${home_dir}"
+    # shellcheck source=../deploy_common.sh
+    source "${COMMON}"
+    # Use a syntactically valid 40-char hex SHA so deploy_init does not die.
+    deploy_init "0000000000000000000000000000000000000000" "test" >/dev/null 2>&1
+    printf 'FORKANA_DEPLOY_MODE=%s\n' "${FORKANA_DEPLOY_MODE}"
+    printf 'PROJECT_NAME=%s\n'        "${PROJECT_NAME}"
+    printf 'ENV_FILE=%s\n'            "${ENV_FILE}"
+    printf 'COMPOSE_BASE=%s\n'        "${COMPOSE_BASE}"
+    printf 'COMPOSE_OVERRIDE=%s\n'    "${COMPOSE_OVERRIDE}"
+    printf 'COMPOSE_FILES=%s\n'       "${COMPOSE_FILES[*]}"
+    printf 'REQUIRED_VARS=%s\n'       "${REQUIRED_VARS[*]}"
+    printf 'SNAPSHOT_DIR=%s\n'        "${SNAPSHOT_DIR}"
+    printf 'MANAGE_REGISTRY=%s\n'     "${MANAGE_REGISTRY}"
+    printf 'MANAGE_DATA_DIRS=%s\n'    "${MANAGE_DATA_DIRS}"
+  )
+}
+
+field() { grep "^$1=" <<<"$2" | head -n1 | cut -d= -f2-; }
+
+# -----------------------------------------------------------------------------
+# Test 1 - standalone mode (no deploy.conf, default)
+# -----------------------------------------------------------------------------
+TMP_STANDALONE="$(mktemp -d)"
+trap 'rm -rf "${TMP_STANDALONE}" "${TMP_FORUMS:-}" "${TMP_FORUMS_OVR:-}" "${TMP_BAD:-}"' EXIT
+
+OUT="$(run_init "${TMP_STANDALONE}")" || {
+  FAIL=$((FAIL + 1)); FAILED_TESTS+=("standalone: deploy_init exited non-zero")
+}
+
+assert_eq "standalone.mode"             "standalone"                                                              "$(field FORKANA_DEPLOY_MODE "${OUT}")"
+assert_eq "standalone.project"          "forkana"                                                                  "$(field PROJECT_NAME        "${OUT}")"
+assert_eq "standalone.env_file"         "${TMP_STANDALONE}/forkana/compose/.env"                                   "$(field ENV_FILE            "${OUT}")"
+assert_eq "standalone.compose_base"     "${TMP_STANDALONE}/forkana/compose/dev.yml"                                "$(field COMPOSE_BASE        "${OUT}")"
+assert_eq "standalone.compose_override" "${TMP_STANDALONE}/forkana/compose/compose.override.yml"                   "$(field COMPOSE_OVERRIDE    "${OUT}")"
+assert_eq "standalone.compose_files"    "-f ${TMP_STANDALONE}/forkana/compose/dev.yml -f ${TMP_STANDALONE}/forkana/compose/compose.override.yml" "$(field COMPOSE_FILES "${OUT}")"
+assert_eq "standalone.required_vars"    "POSTGRES_PASSWORD FORKANA_DOMAIN FORKANA_SECRET_KEY FORKANA_INTERNAL_TOKEN FORKANA_JWT_SECRET" "$(field REQUIRED_VARS "${OUT}")"
+assert_eq "standalone.snapshot_dir"     "${TMP_STANDALONE}/forkana/compose"                                        "$(field SNAPSHOT_DIR        "${OUT}")"
+assert_eq "standalone.manage_registry"  "1"                                                                        "$(field MANAGE_REGISTRY     "${OUT}")"
+assert_eq "standalone.manage_data_dirs" "1"                                                                        "$(field MANAGE_DATA_DIRS    "${OUT}")"
+
+# -----------------------------------------------------------------------------
+# Test 2 - forums mode with neutral defaults (only FORUMS_DIR set)
+# -----------------------------------------------------------------------------
+TMP_FORUMS="$(mktemp -d)"
+mkdir -p "${TMP_FORUMS}/forkana" "${TMP_FORUMS}/forums"
+cat > "${TMP_FORUMS}/forkana/deploy.conf" <<EOF
+FORKANA_DEPLOY_MODE=forums
+FORUMS_DIR=${TMP_FORUMS}/forums
+EOF
+
+OUT="$(run_init "${TMP_FORUMS}")" || {
+  FAIL=$((FAIL + 1)); FAILED_TESTS+=("forums: deploy_init exited non-zero")
+}
+
+assert_eq "forums.mode"             "forums"                                                                                "$(field FORKANA_DEPLOY_MODE "${OUT}")"
+assert_eq "forums.project"          "forums"                                                                                "$(field PROJECT_NAME        "${OUT}")"
+assert_eq "forums.env_file"         "${TMP_FORUMS}/forums/.env"                                                             "$(field ENV_FILE            "${OUT}")"
+assert_eq "forums.compose_base"     "${TMP_FORUMS}/forums/docker-compose.yml"                                               "$(field COMPOSE_BASE        "${OUT}")"
+assert_eq "forums.compose_override" "${TMP_FORUMS}/forums/forkana-override.yml"                                             "$(field COMPOSE_OVERRIDE    "${OUT}")"
+assert_eq "forums.compose_files"    "-f ${TMP_FORUMS}/forums/docker-compose.yml -f ${TMP_FORUMS}/forums/forkana-override.yml" "$(field COMPOSE_FILES "${OUT}")"
+assert_eq "forums.required_vars"    "POSTGRES_FORKANA_PASSWORD FORKANA_DOMAIN FORKANA_ROOT_URL FORKANA_SECRET_KEY FORKANA_INTERNAL_TOKEN FORKANA_JWT_SECRET FORKANA_HOST_PORT" "$(field REQUIRED_VARS "${OUT}")"
+assert_eq "forums.snapshot_dir"     "${TMP_FORUMS}/forkana/snapshots"                                                       "$(field SNAPSHOT_DIR        "${OUT}")"
+assert_eq "forums.manage_registry"  "0"                                                                                     "$(field MANAGE_REGISTRY     "${OUT}")"
+assert_eq "forums.manage_data_dirs" "0"                                                                                     "$(field MANAGE_DATA_DIRS    "${OUT}")"
+
+# -----------------------------------------------------------------------------
+# Test 3 - forums mode with operator overrides via deploy.conf
+#
+# Exercises the FORUMS_ENV_FILE / FORUMS_OVERRIDE_FILE /
+# FORUMS_EXTRA_COMPOSE_FILES knobs so an operator can point at any layout
+# without touching the tracked code.  Relative paths must resolve against
+# ${FORUMS_DIR}.
+# -----------------------------------------------------------------------------
+TMP_FORUMS_OVR="$(mktemp -d)"
+mkdir -p "${TMP_FORUMS_OVR}/forkana" "${TMP_FORUMS_OVR}/stack/cfg" "${TMP_FORUMS_OVR}/stack/secrets"
+cat > "${TMP_FORUMS_OVR}/forkana/deploy.conf" <<EOF
+FORKANA_DEPLOY_MODE=forums
+FORUMS_DIR=${TMP_FORUMS_OVR}/stack
+FORUMS_ENV_FILE=secrets/env
+FORUMS_OVERRIDE_FILE=cfg/forkana-override.yml
+FORUMS_EXTRA_COMPOSE_FILES="cfg/disabled.yml cfg/extras.yml"
+EOF
+
+OUT="$(run_init "${TMP_FORUMS_OVR}")" || {
+  FAIL=$((FAIL + 1)); FAILED_TESTS+=("forums.override: deploy_init exited non-zero")
+}
+
+assert_eq "forums.override.env_file"         "${TMP_FORUMS_OVR}/stack/secrets/env"                                                  "$(field ENV_FILE         "${OUT}")"
+assert_eq "forums.override.compose_override" "${TMP_FORUMS_OVR}/stack/cfg/forkana-override.yml"                                     "$(field COMPOSE_OVERRIDE "${OUT}")"
+assert_eq "forums.override.compose_files"    "-f ${TMP_FORUMS_OVR}/stack/docker-compose.yml -f ${TMP_FORUMS_OVR}/stack/cfg/disabled.yml -f ${TMP_FORUMS_OVR}/stack/cfg/extras.yml -f ${TMP_FORUMS_OVR}/stack/cfg/forkana-override.yml" "$(field COMPOSE_FILES "${OUT}")"
+
+# -----------------------------------------------------------------------------
+# Test 4 - forums mode without FORUMS_DIR must die
+# -----------------------------------------------------------------------------
+TMP_BAD="$(mktemp -d)"
+mkdir -p "${TMP_BAD}/forkana"
+cat > "${TMP_BAD}/forkana/deploy.conf" <<EOF
+FORKANA_DEPLOY_MODE=forums
+EOF
+if run_init "${TMP_BAD}" >/dev/null 2>&1; then
+  FAIL=$((FAIL + 1))
+  FAILED_TESTS+=("forums.no_forums_dir: deploy_init should have died but exited 0")
+else
+  PASS=$((PASS + 1))
+fi
+
+# -----------------------------------------------------------------------------
+# Test 5 - unknown mode must die
+# -----------------------------------------------------------------------------
+cat > "${TMP_BAD}/forkana/deploy.conf" <<EOF
+FORKANA_DEPLOY_MODE=lunar
+EOF
+if run_init "${TMP_BAD}" >/dev/null 2>&1; then
+  FAIL=$((FAIL + 1))
+  FAILED_TESTS+=("unknown_mode: deploy_init should have died but exited 0")
+else
+  PASS=$((PASS + 1))
+fi
+
+# -----------------------------------------------------------------------------
+# Report
+# -----------------------------------------------------------------------------
+printf '\n%d passed, %d failed\n' "${PASS}" "${FAIL}"
+if (( FAIL > 0 )); then
+  printf 'Failures:\n' >&2
+  for f in "${FAILED_TESTS[@]}"; do printf '  - %s\n' "${f}" >&2; done
+  exit 1
+fi


### PR DESCRIPTION
* resolve FORKANA_DEPLOY_MODE in deploy_init from ~/forkana/deploy.conf (default standalone for backward compatibility)
* branch PROJECT_NAME, COMPOSE_FILES, COMPOSE_OVERRIDE, ENV_FILE, REQUIRED_VARS, SNAPSHOT_DIR, MANAGE_REGISTRY, MANAGE_DATA_DIRS per mode
* convert COMPOSE_FILES to a Bash array; rewrite every docker compose call site to use "${COMPOSE_FILES[@]}" so paths with spaces survive
* gate steps 1/1b on MANAGE_DATA_DIRS and step 2's managed-registry branch on MANAGE_REGISTRY; forums dies cleanly when external registry is unreachable
* forums narrows compose_services to (forkana) only and snapshots the override under ~/forkana/snapshots/ off the forums working tree
* add tests/deploy_common.test.sh covering mode resolution, COMPOSE_FILES, REQUIRED_VARS, and negative cases
* document deploy.conf in DEPLOYMENT_GUIDE.md and clarify dev.yml as the standalone-only entry point

Closes #185
Co-authored by: Opus 4.7