### PR TITLE
Fix: Bad redirection after article creation #188

### DIFF
--- a/custom/templates/shared/repo/edit.tmpl
+++ b/custom/templates/shared/repo/edit.tmpl
@@ -65,6 +65,7 @@
               data-has-existing-fork="{{if .HasExistingFork}}true{{else}}false{{end}}"
               data-needs-fork="{{if .NeedsFork}}true{{else}}false{{end}}">
             {{.CsrfTokenHtml}}
+            <input type="hidden" name="redirect_to_article" value="true">
             <input type="hidden" name="last_commit" value="{{.LastCommitID}}">
             <input type="hidden" name="tree_path" value="{{.ReadmeTreePath}}">
             {{/* Required commit choice field - default to direct commit */}}

--- a/routers/web/repo/editor.go
+++ b/routers/web/repo/editor.go
@@ -240,12 +240,8 @@ func redirectForCommitChoice[T any](ctx *context.Context, parsed *preparedEditor
 		}
 	}
 
-	// Check if the request came from an edit or new to the article route
-	// If so, redirect to the article view instead of the file view
-	articleEditPath := path.Join("_edit", parsed.NewBranchName, treePath)
-	articleNewPath := path.Join("_new", parsed.NewBranchName, treePath)
-	if strings.Contains(ctx.Req.URL.Path, articleEditPath) || strings.Contains(ctx.Req.URL.Path, articleNewPath) {
-		ctx.JSONRedirect(ctx.Repo.RepoLink + "?view=article")
+	if ctx.FormBool("redirect_to_article") {
+		ctx.JSONRedirect(ctx.Repo.RepoLink)
 		return
 	}
 

--- a/routers/web/repo/editor.go
+++ b/routers/web/repo/editor.go
@@ -240,11 +240,12 @@ func redirectForCommitChoice[T any](ctx *context.Context, parsed *preparedEditor
 		}
 	}
 
-	// Check if the request came from an edit to the article route
+	// Check if the request came from an edit or new to the article route
 	// If so, redirect to the article view instead of the file view
 	articleEditPath := path.Join("_edit", parsed.NewBranchName, treePath)
-	if strings.Contains(ctx.Req.URL.Path, articleEditPath) {
-		ctx.JSONRedirect(ctx.Repo.RepoLink)
+	articleNewPath := path.Join("_new", parsed.NewBranchName, treePath)
+	if strings.Contains(ctx.Req.URL.Path, articleEditPath) || strings.Contains(ctx.Req.URL.Path, articleNewPath) {
+		ctx.JSONRedirect(ctx.Repo.RepoLink + "?view=article")
 		return
 	}
 

--- a/routers/web/repo/repo.go
+++ b/routers/web/repo/repo.go
@@ -740,7 +740,7 @@ func CreateFirstArticle(ctx *context.Context) {
 	if branch == "" {
 		branch = setting.Repository.DefaultBranch
 	}
-	editorURL := fmt.Sprintf("%s/%s/%s/_new/%s/README.md",
+	editorURL := fmt.Sprintf("%s/%s/%s/_new/%s/README.md?redirect_to_article=1",
 		setting.AppSubURL,
 		util.PathEscapeSegments(ctx.Doer.Name),
 		util.PathEscapeSegments(repo.Name),


### PR DESCRIPTION
After the the creation of the article, we have error page

Fix: redirect to the correct url after the creation of the article

Co written with Gemini 3.1 pro

Close #188 Bad redirection after article creation
