### PR TITLE
Fix 180: Improve UX of "Submit review" modal

### DIFF
--- a/custom/public/assets/css/repo.custom.css
+++ b/custom/public/assets/css/repo.custom.css
@@ -355,6 +355,15 @@
   cursor: pointer;
 }
 
+.review-radio-option.disabled {
+  cursor: not-allowed;
+}
+
+.review-radio-option.disabled .review-radio-label,
+.review-radio-option.disabled .review-radio-desc {
+  color: var(--color-text-tertiary);
+}
+
 .review-radio-option input[type="radio"] {
   margin-top: 4px;
   transform: scale(1.2);

--- a/custom/public/assets/css/repo.custom.css
+++ b/custom/public/assets/css/repo.custom.css
@@ -364,6 +364,11 @@
   color: var(--color-text-tertiary);
 }
 
+.review-radio-option.disabled input[type="radio"] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .review-radio-option input[type="radio"] {
   margin-top: 4px;
   transform: scale(1.2);

--- a/templates/repo/diff/review_submit.tmpl
+++ b/templates/repo/diff/review_submit.tmpl
@@ -45,7 +45,7 @@
 						</div>
 					</label>
 					{{if not $.Issue.IsClosed}}
-						<label class="review-radio-option" {{if $showSelfTooltip}}data-tooltip-content="{{ctx.Locale.Tr "repo.diff.review.self_approve"}}"{{end}}>
+						<label class="review-radio-option{{if $showSelfTooltip}} disabled{{end}}" {{if $showSelfTooltip}}data-tooltip-content="{{ctx.Locale.Tr "repo.diff.review.self_approve"}}"{{end}}>
 							<input type="radio" name="type" value="approve" {{if $showSelfTooltip}}disabled{{end}}>
 							<div class="review-radio-content">
 								<span class="review-radio-label">{{ctx.Locale.Tr "repo.diff.review.approve"}}</span>
@@ -54,7 +54,7 @@
 						</label>
 					{{end}}
 					{{if not $.Issue.IsClosed}}
-						<label class="review-radio-option" {{if $showSelfTooltip}}data-tooltip-content="{{ctx.Locale.Tr "repo.diff.review.self_reject"}}"{{end}}>
+						<label class="review-radio-option{{if $showSelfTooltip}} disabled{{end}}" {{if $showSelfTooltip}}data-tooltip-content="{{ctx.Locale.Tr "repo.diff.review.self_reject"}}"{{end}}>
 							<input type="radio" name="type" value="reject" {{if $showSelfTooltip}}disabled{{end}}>
 							<div class="review-radio-content">
 								<span class="review-radio-label">{{ctx.Locale.Tr "repo.diff.review.reject"}}</span>


### PR DESCRIPTION
Problem
The user submitting a change request can also review the request. When doing so, their options are to Comment or Close, which is appropriate.

However, it isn't sufficiently obvious that the Approve and Request changes aren't possible because the option can be chosen by clicking on the text (good!) and the text is the same in appearance as the other options — only the radio buttons are changed in appearance.

Solution
Grey out the Approve and Request changes options to make it more clear those are unselectable. The grey of "Preview" on the unselected Preview tab would work.

Fix #180 : Improve UX of "Submit review" modal
Co author with Claude Sonnet 4.6