### PR TITLE
feat: implement base64 image widgets and sanitizer support

### DIFF
--- a/custom/public/assets/css/repo.custom.css
+++ b/custom/public/assets/css/repo.custom.css
@@ -503,3 +503,38 @@
 @keyframes editor-spin {
   to { transform: rotate(360deg); }
 }
+
+/* Base64 Image Widget in Toast UI Editor */
+.base64-image-widget {
+  background: var(--color-surface-muted, #f6f8fa) !important;
+  color: var(--color-text-secondary, #57606a) !important;
+  border: 1px solid var(--color-border, #d0d7de) !important;
+  border-radius: 6px !important;
+  font-family: var(--fonts-monospace, monospace) !important;
+  font-size: 11px !important;
+  font-weight: 600 !important;
+  padding: 2px 6px !important;
+  margin: 0 2px !important;
+  cursor: pointer !important;
+  user-select: none !important;
+  display: inline-flex !important;
+  align-items: center !important;
+  gap: 4px !important;
+  transition: all 0.2s ease !important;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05) !important;
+}
+
+.base64-image-widget:hover {
+  background: var(--color-surface-hover, #eaeef2) !important;
+  color: var(--color-text-primary, #24292f) !important;
+  border-color: var(--color-primary, #0969da) !important;
+}
+
+.base64-image-widget .base64-image-icon {
+  flex-shrink: 0;
+  color: var(--color-text-secondary, #57606a);
+}
+
+.base64-image-widget:hover .base64-image-icon {
+  color: var(--color-primary, #0969da);
+}

--- a/modules/markup/sanitizer.go
+++ b/modules/markup/sanitizer.go
@@ -5,7 +5,9 @@
 package markup
 
 import (
+	"net/url"
 	"regexp"
+	"strings"
 	"sync"
 
 	"github.com/microcosm-cc/bluemonday"
@@ -48,4 +50,35 @@ func GetDefaultSanitizer() *Sanitizer {
 func ResetDefaultSanitizerForTesting() {
 	defaultSanitizer = nil
 	defaultSanitizerOnce = sync.Once{}
+}
+
+func allowDataURIImagesPolicy(u *url.URL) bool {
+	// Enforce a size limit of 2MB to protect against storage bloat and slow decoding (Issue 11)
+	if len(u.Opaque) > 2*1024*1024 {
+		return false
+	}
+	// Replicate bluemonday's strict validation (Issue 2)
+	// It must start with one of the allowed mime types followed by ;base64,
+	parts := strings.SplitN(u.Opaque, ";base64,", 2)
+	if len(parts) != 2 {
+		return false
+	}
+	mimeType := parts[0]
+	if mimeType != "image/gif" && mimeType != "image/jpeg" && mimeType != "image/png" &&
+		mimeType != "image/webp" && mimeType != "image/svg+xml" {
+		return false
+	}
+	// Validate that the remaining data is valid base64 (only alphanumeric, +, /, and =)
+	payload := parts[1]
+	if len(payload) == 0 {
+		return false
+	}
+	for _, char := range payload {
+		if !((char >= 'A' && char <= 'Z') || (char >= 'a' && char <= 'z') ||
+			(char >= '0' && char <= '9') || char == '+' || char == '/' || char == '=' ||
+			char == '\r' || char == '\n' || char == '\t' || char == ' ') {
+			return false
+		}
+	}
+	return true
 }

--- a/modules/markup/sanitizer_custom.go
+++ b/modules/markup/sanitizer_custom.go
@@ -15,7 +15,7 @@ import (
 func (st *Sanitizer) addSanitizerRules(policy *bluemonday.Policy, rules []setting.MarkupSanitizerRule) {
 	for _, rule := range rules {
 		if rule.AllowDataURIImages {
-			policy.AllowDataURIImages()
+			policy.AllowURLSchemeWithCustomPolicy("data", allowDataURIImagesPolicy)
 		}
 		if rule.Element != "" {
 			if rule.Regexp != "" {

--- a/modules/markup/sanitizer_default.go
+++ b/modules/markup/sanitizer_default.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/url"
 	"regexp"
-	"strings"
 
 	"code.gitea.io/gitea/modules/setting"
 

--- a/modules/markup/sanitizer_default.go
+++ b/modules/markup/sanitizer_default.go
@@ -69,9 +69,7 @@ func (st *Sanitizer) createDefaultPolicy() *bluemonday.Policy {
 		}
 
 		if allowDataURIImages {
-			policy.AllowURLSchemeWithCustomPolicy("data", func(u *url.URL) bool {
-				return strings.HasPrefix(u.Opaque, "image/")
-			})
+			policy.AllowURLSchemeWithCustomPolicy("data", allowDataURIImagesPolicy)
 		} else {
 			policy.AllowURLSchemeWithCustomPolicy("data", disallowScheme)
 		}

--- a/modules/markup/sanitizer_default.go
+++ b/modules/markup/sanitizer_default.go
@@ -44,6 +44,9 @@ func (st *Sanitizer) createDefaultPolicy() *bluemonday.Policy {
 		policy.AllowURLSchemeWithCustomPolicy("javascript", disallowScheme)
 		policy.AllowURLSchemeWithCustomPolicy("vbscript", disallowScheme)
 
+		// Allow data:image/... URIs (e.g. base64-encoded images) only if explicitly
+		// requested by external sanitizer rules or markup renderers configuration,
+		// preventing arbitrary data URIs from being processed otherwise.
 		allowDataURIImages := false
 		for _, rule := range setting.ExternalSanitizerRules {
 			if rule.AllowDataURIImages {

--- a/modules/markup/sanitizer_default.go
+++ b/modules/markup/sanitizer_default.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/url"
 	"regexp"
+	"strings"
 
 	"code.gitea.io/gitea/modules/setting"
 
@@ -42,7 +43,35 @@ func (st *Sanitizer) createDefaultPolicy() *bluemonday.Policy {
 		}
 		policy.AllowURLSchemeWithCustomPolicy("javascript", disallowScheme)
 		policy.AllowURLSchemeWithCustomPolicy("vbscript", disallowScheme)
-		policy.AllowURLSchemeWithCustomPolicy("data", disallowScheme)
+
+		allowDataURIImages := false
+		for _, rule := range setting.ExternalSanitizerRules {
+			if rule.AllowDataURIImages {
+				allowDataURIImages = true
+				break
+			}
+		}
+		if !allowDataURIImages {
+			for _, renderer := range setting.ExternalMarkupRenderers {
+				for _, rule := range renderer.MarkupSanitizerRules {
+					if rule.AllowDataURIImages {
+						allowDataURIImages = true
+						break
+					}
+				}
+				if allowDataURIImages {
+					break
+				}
+			}
+		}
+
+		if allowDataURIImages {
+			policy.AllowURLSchemeWithCustomPolicy("data", func(u *url.URL) bool {
+				return strings.HasPrefix(u.Opaque, "image/")
+			})
+		} else {
+			policy.AllowURLSchemeWithCustomPolicy("data", disallowScheme)
+		}
 	}
 
 	// Allow classes for org mode list item status.

--- a/modules/markup/sanitizer_default_test.go
+++ b/modules/markup/sanitizer_default_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"code.gitea.io/gitea/modules/setting"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/modules/markup/sanitizer_default_test.go
+++ b/modules/markup/sanitizer_default_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"code.gitea.io/gitea/modules/setting"
+	"code.gitea.io/gitea/modules/test"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -76,18 +77,61 @@ func TestSanitizer(t *testing.T) {
 }
 
 func TestSanitizerAllowDataURIImages(t *testing.T) {
-	setting.ExternalSanitizerRules = []setting.MarkupSanitizerRule{
+	defer test.MockVariableValue(&setting.ExternalSanitizerRules, []setting.MarkupSanitizerRule{
 		{
 			AllowDataURIImages: true,
 		},
-	}
+	})()
+	defer test.MockVariableValue(&setting.ExternalMarkupRenderers, nil)()
 	ResetDefaultSanitizerForTesting()
-	defer func() {
-		setting.ExternalSanitizerRules = nil
-		ResetDefaultSanitizerForTesting()
-	}()
+	defer ResetDefaultSanitizerForTesting()
 
+	// Positive case: valid base64 PNG image remains
 	input := `<img src="data:image/png;base64,iVBORw0KGgoAAAANS">`
 	output := string(Sanitize(input))
 	assert.Contains(t, output, `src="data:image/png;base64,iVBORw0KGgoAAAANS"`)
+
+	// Negative case: non-image data URI is stripped
+	input = `<img src="data:text/html;base64,PGh0bWw+aGVsbG88L2h0bWw+">`
+	output = string(Sanitize(input))
+	assert.NotContains(t, output, `src=`)
+
+	// Negative case: un-encoded SVG / raw SVG (non-base64) is stripped
+	input = `<img src="data:image/svg+xml,<svg/onload=alert(1)>">`
+	output = string(Sanitize(input))
+	assert.NotContains(t, output, `src=`)
+
+	// Negative case: invalid base64 payload is stripped
+	input = `<img src="data:image/png;base64,###not-base64###">`
+	output = string(Sanitize(input))
+	assert.NotContains(t, output, `src=`)
+
+	// Negative case: unknown/unsupported image subtype is stripped
+	input = `<img src="data:image/foo;base64,AAAA">`
+	output = string(Sanitize(input))
+	assert.NotContains(t, output, `src=`)
+
+	// Negative case: image exceeding 2MB size cap is stripped
+	largePayload := make([]byte, 2*1024*1024+100)
+	for i := range largePayload {
+		largePayload[i] = 'A'
+	}
+	input = `<img src="data:image/png;base64,` + string(largePayload) + `">`
+	output = string(Sanitize(input))
+	assert.NotContains(t, output, `src=`)
+
+	// Verify that when the rule is NOT set, the valid base64 PNG is stripped
+	func() {
+		defer test.MockVariableValue(&setting.ExternalSanitizerRules, nil)()
+		ResetDefaultSanitizerForTesting()
+		defer ResetDefaultSanitizerForTesting()
+
+		input := `<img src="data:image/png;base64,iVBORw0KGgoAAAANS">`
+		output := string(Sanitize(input))
+		assert.NotContains(t, output, `src=`)
+
+		input = `<a href="data:1234">bad</a>`
+		output = string(Sanitize(input))
+		assert.NotContains(t, output, `href=`)
+	}()
 }

--- a/modules/markup/sanitizer_default_test.go
+++ b/modules/markup/sanitizer_default_test.go
@@ -7,6 +7,7 @@ package markup
 import (
 	"testing"
 
+	"code.gitea.io/gitea/modules/setting"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -71,4 +72,21 @@ func TestSanitizer(t *testing.T) {
 	for i := 0; i < len(testCases); i += 2 {
 		assert.Equal(t, testCases[i+1], string(Sanitize(testCases[i])))
 	}
+}
+
+func TestSanitizerAllowDataURIImages(t *testing.T) {
+	setting.ExternalSanitizerRules = []setting.MarkupSanitizerRule{
+		{
+			AllowDataURIImages: true,
+		},
+	}
+	ResetDefaultSanitizerForTesting()
+	defer func() {
+		setting.ExternalSanitizerRules = nil
+		ResetDefaultSanitizerForTesting()
+	}()
+
+	input := `<img src="data:image/png;base64,iVBORw0KGgoAAAANS">`
+	output := string(Sanitize(input))
+	assert.Contains(t, output, `src="data:image/png;base64,iVBORw0KGgoAAAANS"`)
 }

--- a/web_src/js/features/comp/ToastCommentEditor.ts
+++ b/web_src/js/features/comp/ToastCommentEditor.ts
@@ -21,6 +21,21 @@ import {
   initDropzone,
 } from '../dropzone.ts';
 
+const imageIconSvg = `
+<svg class="base64-image-icon" width="12" height="12" viewBox="0 0 16 16" fill="currentColor" style="vertical-align: middle;">
+  <path d="M1.75 2.5a.25.25 0 0 0-.25.25v10.5c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25V2.75a.25.25 0 0 0-.25-.25H1.75zM0 2.75C0 1.784.784 1 1.75 1h12.5c.966 0 1.75.784 1.75 1.75v10.5A1.75 1.75 0 0 1 14.25 15H1.75A1.75 1.75 0 0 1 0 13.25V2.75zm9.5 4.75a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm-7.25 5h11.5a.25.25 0 0 0 .222-.365l-3.5-7a.25.25 0 0 0-.43 0L7.5 10.386l-2.066-3.1a.25.25 0 0 0-.416 0l-3 4.5A.25.25 0 0 0 2.25 12.5z"/>
+</svg>
+`;
+
+function formatBytes(bytes: number, decimals = 1): string {
+  if (bytes === 0) return '0 B';
+  const k = 1024;
+  const dm = Math.max(0, decimals);
+  const sizes = ['B', 'KB', 'MB', 'GB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return `${parseFloat((bytes / (k ** i)).toFixed(dm))} ${sizes[i]}`;
+}
+
 // Event dispatched when editor content changes
 export const EventEditorContentChanged = 'ce-editor-content-changed';
 
@@ -110,8 +125,78 @@ export class ToastCommentEditor {
           }
         },
       },
+      widgetRules: [
+        {
+          rule: /!\[([^\]]*)\]\((data:image\/[a-zA-Z+.-]+;base64,[A-Za-z0-9+/=\s]{50,})\)/,
+          toDOM: (text: string) => {
+            let isWysiwyg = false;
+            try {
+              if (this.editor && typeof this.editor.isWysiwygMode === 'function') {
+                isWysiwyg = this.editor.isWysiwygMode();
+              }
+            } catch {}
+
+            if (!isWysiwyg) {
+              const activeTab = this.editorWrapper.querySelector('.toastui-editor-mode-switch .tab-item.active');
+              if (activeTab && (activeTab.textContent?.includes('Visual') || activeTab.textContent?.includes('WYSIWYG'))) {
+                isWysiwyg = true;
+              }
+            }
+
+            const match = /!\[([^\]]*)\]\((data:image\/[a-zA-Z+.-]+;base64,[A-Za-z0-9+/=\s]+)\)/.exec(text);
+            const altText = match ? match[1] : '';
+            const base64Url = match ? match[2] : '';
+
+            if (isWysiwyg) {
+              const img = document.createElement('img');
+              img.src = base64Url;
+              img.alt = altText || 'Image';
+              img.className = 'base64-wysiwyg-preview';
+              img.style.maxWidth = '100%';
+              return img;
+            }
+
+            const mimeMatch = /^data:(image\/[a-zA-Z+.-]+);base64,/.exec(base64Url);
+            const mimeType = mimeMatch ? mimeMatch[1] : 'image';
+            const extension = mimeType.replace('image/', '').toUpperCase();
+            const sizeBytes = Math.round((base64Url.length - (base64Url.indexOf(',') + 1)) * 0.75);
+            const formattedSize = formatBytes(sizeBytes);
+
+            const el = document.createElement('span');
+            el.className = 'base64-image-widget';
+            el.title = `Alt: ${altText} | Base64 Encoded Image - Click to copy original data URI`;
+            el.innerHTML = `${imageIconSvg} <span>Base64 Image (${extension}, ${formattedSize}${altText ? ` - ${altText}` : ''})</span>`;
+
+            el.addEventListener('click', async (e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              try {
+                await navigator.clipboard.writeText(base64Url);
+                const label = el.querySelector('span');
+                if (label) {
+                  const originalText = label.textContent;
+                  label.textContent = 'Copied to clipboard!';
+                  setTimeout(() => {
+                    label.textContent = originalText;
+                  }, 2000);
+                }
+              } catch (err) {
+                console.error('Failed to copy to clipboard', err);
+              }
+            });
+
+            return el;
+          },
+        },
+      ],
     });
 
+    // Override getMarkdown to strip internal $$widget placeholders
+    const originalGetMarkdown = this.editor.getMarkdown.bind(this.editor);
+    this.editor.getMarkdown = () => {
+      const content = originalGetMarkdown();
+      return content.replace(/\$\$widget\d+\s+(!\[[^\]]*\]\(data:image\/[a-zA-Z+.-]+;base64,[A-Za-z0-9+/=\s]{50,}\))\$\$/g, '$1');
+    };
     // Set initial content from textarea
     if (this.textarea.value) {
       this.editor.setMarkdown(this.textarea.value);

--- a/web_src/js/features/comp/ToastCommentEditor.ts
+++ b/web_src/js/features/comp/ToastCommentEditor.ts
@@ -160,11 +160,11 @@ export class ToastCommentEditor {
         e.preventDefault();
         e.stopPropagation();
         this.handleDroppedFiles(e.dataTransfer.files);
-      });
+      }, true);
       this.editorWrapper.addEventListener('dragover', (e: DragEvent) => {
         e.preventDefault();
         e.dataTransfer.dropEffect = 'copy';
-      });
+      }, true);
 
       // Clean up markdown links when an attachment is removed from the Dropzone
       this.attachedDropzoneInst.on(DropzoneCustomEventRemovedFile, ({fileUuid}: {fileUuid: string}) => {

--- a/web_src/js/features/comp/ToastCommentEditor.ts
+++ b/web_src/js/features/comp/ToastCommentEditor.ts
@@ -20,21 +20,7 @@ import {
   generateMarkdownLinkForAttachment,
   initDropzone,
 } from '../dropzone.ts';
-
-const imageIconSvg = `
-<svg class="base64-image-icon" width="12" height="12" viewBox="0 0 16 16" fill="currentColor" style="vertical-align: middle;">
-  <path d="M1.75 2.5a.25.25 0 0 0-.25.25v10.5c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25V2.75a.25.25 0 0 0-.25-.25H1.75zM0 2.75C0 1.784.784 1 1.75 1h12.5c.966 0 1.75.784 1.75 1.75v10.5A1.75 1.75 0 0 1 14.25 15H1.75A1.75 1.75 0 0 1 0 13.25V2.75zm9.5 4.75a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm-7.25 5h11.5a.25.25 0 0 0 .222-.365l-3.5-7a.25.25 0 0 0-.43 0L7.5 10.386l-2.066-3.1a.25.25 0 0 0-.416 0l-3 4.5A.25.25 0 0 0 2.25 12.5z"/>
-</svg>
-`;
-
-function formatBytes(bytes: number, decimals = 1): string {
-  if (bytes === 0) return '0 B';
-  const k = 1024;
-  const dm = Math.max(0, decimals);
-  const sizes = ['B', 'KB', 'MB', 'GB'];
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
-  return `${parseFloat((bytes / (k ** i)).toFixed(dm))} ${sizes[i]}`;
-}
+import {createBase64WidgetRule} from './base64ImageWidget.ts';
 
 // Event dispatched when editor content changes
 export const EventEditorContentChanged = 'ce-editor-content-changed';
@@ -126,72 +112,7 @@ export class ToastCommentEditor {
         },
       },
       widgetRules: [
-        {
-          rule: /!\[([^\]]*)\]\((data:image\/[a-zA-Z+.-]+;base64,[A-Za-z0-9+/=\s]{50,})\)/,
-          toDOM: (text: string) => {
-            let isWysiwyg = false;
-            try {
-              if (this.editor && typeof this.editor.isWysiwygMode === 'function') {
-                isWysiwyg = this.editor.isWysiwygMode();
-              }
-            } catch {}
-
-            if (!isWysiwyg) {
-              const activeTab = this.editorWrapper.querySelector('.toastui-editor-mode-switch .tab-item.active');
-              if (activeTab && (activeTab.textContent?.includes('Visual') || activeTab.textContent?.includes('WYSIWYG'))) {
-                isWysiwyg = true;
-              }
-            }
-
-            const match = /!\[([^\]]*)\]\((data:image\/[a-zA-Z+.-]+;base64,[A-Za-z0-9+/=\s]+)\)/.exec(text);
-            const altText = match ? match[1] : '';
-            const base64Url = match ? match[2] : '';
-
-            if (isWysiwyg) {
-              const img = document.createElement('img');
-              img.src = base64Url;
-              img.alt = altText || 'Image';
-              img.className = 'base64-wysiwyg-preview';
-              img.style.maxWidth = '100%';
-              return img;
-            }
-
-            const mimeMatch = /^data:(image\/[a-zA-Z+.-]+);base64,/.exec(base64Url);
-            const mimeType = mimeMatch ? mimeMatch[1] : 'image';
-            const extension = mimeType.replace('image/', '').toUpperCase();
-            const sizeBytes = Math.round((base64Url.length - (base64Url.indexOf(',') + 1)) * 0.75);
-            const formattedSize = formatBytes(sizeBytes);
-
-            const el = document.createElement('span');
-            el.className = 'base64-image-widget';
-            el.title = `Alt: ${altText} | Base64 Encoded Image - Click to copy original data URI`;
-            el.innerHTML = imageIconSvg.trim();
-
-            const label = document.createElement('span');
-            label.textContent = `Base64 Image (${extension}, ${formattedSize}${altText ? ` - ${altText}` : ''})`;
-            el.append(label);
-
-            el.addEventListener('click', async (e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              try {
-                await navigator.clipboard.writeText(base64Url);
-                const label = el.querySelector('span');
-                if (label) {
-                  const originalText = label.textContent;
-                  label.textContent = 'Copied to clipboard!';
-                  setTimeout(() => {
-                    label.textContent = originalText;
-                  }, 2000);
-                }
-              } catch (err) {
-                console.error('Failed to copy to clipboard', err);
-              }
-            });
-
-            return el;
-          },
-        },
+        createBase64WidgetRule(() => this.editor, () => this.editorWrapper),
       ],
     });
 

--- a/web_src/js/features/comp/ToastCommentEditor.ts
+++ b/web_src/js/features/comp/ToastCommentEditor.ts
@@ -20,7 +20,7 @@ import {
   generateMarkdownLinkForAttachment,
   initDropzone,
 } from '../dropzone.ts';
-import {createBase64WidgetRule} from './base64ImageWidget.ts';
+import {createBase64WidgetRule, installBase64WidgetPatch} from './base64ImageWidget.ts';
 
 // Event dispatched when editor content changes
 export const EventEditorContentChanged = 'ce-editor-content-changed';
@@ -117,11 +117,7 @@ export class ToastCommentEditor {
     });
 
     // Override getMarkdown to strip internal $$widget placeholders
-    const originalGetMarkdown = this.editor.getMarkdown.bind(this.editor);
-    this.editor.getMarkdown = () => {
-      const content = originalGetMarkdown();
-      return content.replace(/\$\$widget\d+\s+(!\[[^\]]*\]\(data:image\/[a-zA-Z+.-]+;base64,[A-Za-z0-9+/=\s]{50,}\))\$\$/g, '$1');
-    };
+    installBase64WidgetPatch(this.editor);
     // Set initial content from textarea
     if (this.textarea.value) {
       this.editor.setMarkdown(this.textarea.value);
@@ -160,11 +156,11 @@ export class ToastCommentEditor {
         e.preventDefault();
         e.stopPropagation();
         this.handleDroppedFiles(e.dataTransfer.files);
-      }, true);
+      }, false);
       this.editorWrapper.addEventListener('dragover', (e: DragEvent) => {
         e.preventDefault();
         e.dataTransfer.dropEffect = 'copy';
-      }, true);
+      }, false);
 
       // Clean up markdown links when an attachment is removed from the Dropzone
       this.attachedDropzoneInst.on(DropzoneCustomEventRemovedFile, ({fileUuid}: {fileUuid: string}) => {

--- a/web_src/js/features/comp/ToastCommentEditor.ts
+++ b/web_src/js/features/comp/ToastCommentEditor.ts
@@ -165,7 +165,11 @@ export class ToastCommentEditor {
             const el = document.createElement('span');
             el.className = 'base64-image-widget';
             el.title = `Alt: ${altText} | Base64 Encoded Image - Click to copy original data URI`;
-            el.innerHTML = `${imageIconSvg} <span>Base64 Image (${extension}, ${formattedSize}${altText ? ` - ${altText}` : ''})</span>`;
+            el.innerHTML = imageIconSvg.trim();
+
+            const label = document.createElement('span');
+            label.textContent = `Base64 Image (${extension}, ${formattedSize}${altText ? ` - ${altText}` : ''})`;
+            el.append(label);
 
             el.addEventListener('click', async (e) => {
               e.preventDefault();

--- a/web_src/js/features/comp/ToastCommentEditor.ts
+++ b/web_src/js/features/comp/ToastCommentEditor.ts
@@ -112,7 +112,7 @@ export class ToastCommentEditor {
         },
       },
       widgetRules: [
-        createBase64WidgetRule(() => this.editor, () => this.editorWrapper),
+        createBase64WidgetRule(() => this.editor),
       ],
     });
 

--- a/web_src/js/features/comp/base64ImageWidget.ts
+++ b/web_src/js/features/comp/base64ImageWidget.ts
@@ -1,18 +1,15 @@
 // @ts-expect-error - @toast-ui/editor has type definition issues with package.json exports
 import type Editor from '@toast-ui/editor';
 
-export const imageIconSvg = `
-<svg class="base64-image-icon" width="12" height="12" viewBox="0 0 16 16" fill="currentColor" style="vertical-align: middle;">
-  <path d="M1.75 2.5a.25.25 0 0 0-.25.25v10.5c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25V2.75a.25.25 0 0 0-.25-.25H1.75zM0 2.75C0 1.784.784 1 1.75 1h12.5c.966 0 1.75.784 1.75 1.75v10.5A1.75 1.75 0 0 1 14.25 15H1.75A1.75 1.75 0 0 1 0 13.25V2.75zm9.5 4.75a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm-7.25 5h11.5a.25.25 0 0 0 .222-.365l-3.5-7a.25.25 0 0 0-.43 0L7.5 10.386l-2.066-3.1a.25.25 0 0 0-.416 0l-3 4.5A.25.25 0 0 0 2.25 12.5z"/>
-</svg>
-`;
-
 export function formatBytes(bytes: number, decimals = 1): string {
-  if (bytes === 0) return '0 B';
+  if (bytes <= 0) return '0 B';
   const k = 1024;
   const dm = Math.max(0, decimals);
   const sizes = ['B', 'KB', 'MB', 'GB'];
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  let i = Math.floor(Math.log(bytes) / Math.log(k));
+  if (i >= sizes.length) {
+    i = sizes.length - 1;
+  }
   return `${parseFloat((bytes / (k ** i)).toFixed(dm))} ${sizes[i]}`;
 }
 
@@ -21,7 +18,7 @@ export function createBase64WidgetRule(
   getEditor: () => Editor | null,
 ) {
   return {
-    rule: /!\[([^\]]*)\]\((data:image\/[a-zA-Z+.-]+;base64,[A-Za-z0-9+/=\s]{50,})\)/,
+    rule: /!\[([^\]]*)\]\((data:image\/[a-zA-Z+.-]+;base64,[A-Za-z0-9+/=]{50,})\)/,
     toDOM(text: string) {
       let isWysiwyg = false;
       const editor = getEditor();
@@ -31,7 +28,7 @@ export function createBase64WidgetRule(
         }
       } catch {}
 
-      const match = /!\[([^\]]*)\]\((data:image\/[a-zA-Z+.-]+;base64,[A-Za-z0-9+/=\s]+)\)/.exec(text);
+      const match = /!\[([^\]]*)\]\((data:image\/[a-zA-Z+.-]+;base64,[A-Za-z0-9+/=]+)\)/.exec(text);
       const altText = match ? match[1] : '';
       const base64Url = match ? match[2] : '';
 
@@ -53,31 +50,64 @@ export function createBase64WidgetRule(
       const el = document.createElement('span');
       el.className = 'base64-image-widget';
       el.title = `Alt: ${altText} | Base64 Encoded Image - Click to copy original data URI`;
-      el.innerHTML = imageIconSvg.trim();
+
+      // Construct SVG programmatically to avoid innerHTML XSS sinks (Issue 10)
+      const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+      svg.setAttribute('class', 'base64-image-icon');
+      svg.setAttribute('width', '12');
+      svg.setAttribute('height', '12');
+      svg.setAttribute('viewBox', '0 0 16 16');
+      svg.setAttribute('fill', 'currentColor');
+      svg.style.verticalAlign = 'middle';
+
+      const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
+      path.setAttribute('d', 'M1.75 2.5a.25.25 0 0 0-.25.25v10.5c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25V2.75a.25.25 0 0 0-.25-.25H1.75zM0 2.75C0 1.784.784 1 1.75 1h12.5c.966 0 1.75.784 1.75 1.75v10.5A1.75 1.75 0 0 1 14.25 15H1.75A1.75 1.75 0 0 1 0 13.25V2.75zm9.5 4.75a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm-7.25 5h11.5a.25.25 0 0 0 .222-.365l-3.5-7a.25.25 0 0 0-.43 0L7.5 10.386l-2.066-3.1a.25.25 0 0 0-.416 0l-3 4.5A.25.25 0 0 0 2.25 12.5z');
+      svg.append(path);
+      el.append(svg);
 
       const label = document.createElement('span');
       label.textContent = `Base64 Image (${extension}, ${formattedSize}${altText ? ` - ${altText}` : ''})`;
       el.append(label);
 
-      el.addEventListener('click', async (e) => {
+      // Named click handler to prevent leaks (Issue 8)
+      const onWidgetClick = async (e: MouseEvent) => {
         e.preventDefault();
         e.stopPropagation();
         try {
           await navigator.clipboard.writeText(base64Url);
-          const label = el.querySelector('span');
-          if (label) {
-            const originalText = label.textContent;
-            label.textContent = 'Copied to clipboard!';
+          const labelSpan = el.querySelector('span');
+          if (labelSpan) {
+            const originalText = labelSpan.textContent;
+            labelSpan.textContent = 'Copied to clipboard!';
             setTimeout(() => {
-              label.textContent = originalText;
+              labelSpan.textContent = originalText;
             }, 2000);
           }
         } catch (err) {
           console.error('Failed to copy to clipboard', err);
         }
+      };
+
+      el.addEventListener('click', onWidgetClick);
+
+      // MutationObserver to clean up listener upon detachment (Issue 8)
+      const observer = new MutationObserver(() => {
+        if (!document.body.contains(el)) {
+          el.removeEventListener('click', onWidgetClick);
+          observer.disconnect();
+        }
       });
+      observer.observe(document.body, {childList: true, subtree: true});
 
       return el;
     },
+  };
+}
+
+export function installBase64WidgetPatch(editor: Editor): void {
+  const originalGetMarkdown = editor.getMarkdown.bind(editor);
+  editor.getMarkdown = () => {
+    const content = originalGetMarkdown();
+    return content.replace(/\$\$widget\d+\s([\s\S]*?)\$\$/g, '$1');
   };
 }

--- a/web_src/js/features/comp/base64ImageWidget.ts
+++ b/web_src/js/features/comp/base64ImageWidget.ts
@@ -18,7 +18,6 @@ export function formatBytes(bytes: number, decimals = 1): string {
 
 export function createBase64WidgetRule(
   getEditor: () => Editor | null,
-  getContainer: () => HTMLElement | null,
 ) {
   return {
     rule: /!\[([^\]]*)\]\((data:image\/[a-zA-Z+.-]+;base64,[A-Za-z0-9+/=\s]{50,})\)/,
@@ -30,14 +29,6 @@ export function createBase64WidgetRule(
           isWysiwyg = editor.isWysiwygMode();
         }
       } catch {}
-
-      if (!isWysiwyg) {
-        const container = getContainer();
-        const activeTab = container?.querySelector('.toastui-editor-mode-switch .tab-item.active');
-        if (activeTab && (activeTab.textContent?.includes('Visual') || activeTab.textContent?.includes('WYSIWYG'))) {
-          isWysiwyg = true;
-        }
-      }
 
       const match = /!\[([^\]]*)\]\((data:image\/[a-zA-Z+.-]+;base64,[A-Za-z0-9+/=\s]+)\)/.exec(text);
       const altText = match ? match[1] : '';

--- a/web_src/js/features/comp/base64ImageWidget.ts
+++ b/web_src/js/features/comp/base64ImageWidget.ts
@@ -1,0 +1,91 @@
+// @ts-expect-error - @toast-ui/editor has type definition issues with package.json exports
+import Editor from '@toast-ui/editor';
+
+export const imageIconSvg = `
+<svg class="base64-image-icon" width="12" height="12" viewBox="0 0 16 16" fill="currentColor" style="vertical-align: middle;">
+  <path d="M1.75 2.5a.25.25 0 0 0-.25.25v10.5c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25V2.75a.25.25 0 0 0-.25-.25H1.75zM0 2.75C0 1.784.784 1 1.75 1h12.5c.966 0 1.75.784 1.75 1.75v10.5A1.75 1.75 0 0 1 14.25 15H1.75A1.75 1.75 0 0 1 0 13.25V2.75zm9.5 4.75a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm-7.25 5h11.5a.25.25 0 0 0 .222-.365l-3.5-7a.25.25 0 0 0-.43 0L7.5 10.386l-2.066-3.1a.25.25 0 0 0-.416 0l-3 4.5A.25.25 0 0 0 2.25 12.5z"/>
+</svg>
+`;
+
+export function formatBytes(bytes: number, decimals = 1): string {
+  if (bytes === 0) return '0 B';
+  const k = 1024;
+  const dm = Math.max(0, decimals);
+  const sizes = ['B', 'KB', 'MB', 'GB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return `${parseFloat((bytes / (k ** i)).toFixed(dm))} ${sizes[i]}`;
+}
+
+export function createBase64WidgetRule(
+  getEditor: () => Editor | null,
+  getContainer: () => HTMLElement | null,
+) {
+  return {
+    rule: /!\[([^\]]*)\]\((data:image\/[a-zA-Z+.-]+;base64,[A-Za-z0-9+/=\s]{50,})\)/,
+    toDOM(text: string) {
+      let isWysiwyg = false;
+      const editor = getEditor();
+      try {
+        if (editor && typeof editor.isWysiwygMode === 'function') {
+          isWysiwyg = editor.isWysiwygMode();
+        }
+      } catch {}
+
+      if (!isWysiwyg) {
+        const container = getContainer();
+        const activeTab = container?.querySelector('.toastui-editor-mode-switch .tab-item.active');
+        if (activeTab && (activeTab.textContent?.includes('Visual') || activeTab.textContent?.includes('WYSIWYG'))) {
+          isWysiwyg = true;
+        }
+      }
+
+      const match = /!\[([^\]]*)\]\((data:image\/[a-zA-Z+.-]+;base64,[A-Za-z0-9+/=\s]+)\)/.exec(text);
+      const altText = match ? match[1] : '';
+      const base64Url = match ? match[2] : '';
+
+      if (isWysiwyg) {
+        const img = document.createElement('img');
+        img.src = base64Url;
+        img.alt = altText || 'Image';
+        img.className = 'base64-wysiwyg-preview';
+        img.style.maxWidth = '100%';
+        return img;
+      }
+
+      const mimeMatch = /^data:(image\/[a-zA-Z+.-]+);base64,/.exec(base64Url);
+      const mimeType = mimeMatch ? mimeMatch[1] : 'image';
+      const extension = mimeType.replace('image/', '').toUpperCase();
+      const sizeBytes = Math.round((base64Url.length - (base64Url.indexOf(',') + 1)) * 0.75);
+      const formattedSize = formatBytes(sizeBytes);
+
+      const el = document.createElement('span');
+      el.className = 'base64-image-widget';
+      el.title = `Alt: ${altText} | Base64 Encoded Image - Click to copy original data URI`;
+      el.innerHTML = imageIconSvg.trim();
+
+      const label = document.createElement('span');
+      label.textContent = `Base64 Image (${extension}, ${formattedSize}${altText ? ` - ${altText}` : ''})`;
+      el.append(label);
+
+      el.addEventListener('click', async (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        try {
+          await navigator.clipboard.writeText(base64Url);
+          const label = el.querySelector('span');
+          if (label) {
+            const originalText = label.textContent;
+            label.textContent = 'Copied to clipboard!';
+            setTimeout(() => {
+              label.textContent = originalText;
+            }, 2000);
+          }
+        } catch (err) {
+          console.error('Failed to copy to clipboard', err);
+        }
+      });
+
+      return el;
+    },
+  };
+}

--- a/web_src/js/features/comp/base64ImageWidget.ts
+++ b/web_src/js/features/comp/base64ImageWidget.ts
@@ -1,5 +1,5 @@
 // @ts-expect-error - @toast-ui/editor has type definition issues with package.json exports
-import Editor from '@toast-ui/editor';
+import type Editor from '@toast-ui/editor';
 
 export const imageIconSvg = `
 <svg class="base64-image-icon" width="12" height="12" viewBox="0 0 16 16" fill="currentColor" style="vertical-align: middle;">
@@ -17,6 +17,7 @@ export function formatBytes(bytes: number, decimals = 1): string {
 }
 
 export function createBase64WidgetRule(
+  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents -- Editor type has issues
   getEditor: () => Editor | null,
 ) {
   return {

--- a/web_src/js/features/toast-editor.ts
+++ b/web_src/js/features/toast-editor.ts
@@ -60,7 +60,7 @@ export async function createToastEditor(
       },
     },
     widgetRules: [
-      createBase64WidgetRule(() => editor, () => container),
+      createBase64WidgetRule(() => editor),
     ],
   });
 

--- a/web_src/js/features/toast-editor.ts
+++ b/web_src/js/features/toast-editor.ts
@@ -113,7 +113,11 @@ export async function createToastEditor(
           const el = document.createElement('span');
           el.className = 'base64-image-widget';
           el.title = `Alt: ${altText} | Base64 Encoded Image - Click to copy original data URI`;
-          el.innerHTML = `${imageIconSvg} <span>Base64 Image (${extension}, ${formattedSize}${altText ? ` - ${altText}` : ''})</span>`;
+          el.innerHTML = imageIconSvg.trim();
+
+          const label = document.createElement('span');
+          label.textContent = `Base64 Image (${extension}, ${formattedSize}${altText ? ` - ${altText}` : ''})`;
+          el.append(label);
 
           el.addEventListener('click', async (e) => {
             e.preventDefault();

--- a/web_src/js/features/toast-editor.ts
+++ b/web_src/js/features/toast-editor.ts
@@ -44,7 +44,9 @@ export async function createToastEditor(
   }
 
   // Initialize Toast UI Editor
-  const editor = new Editor({
+  /* eslint-disable prefer-const */
+  let editor: Editor;
+  editor = new Editor({
     el: container,
     height,
     initialEditType,
@@ -60,9 +62,10 @@ export async function createToastEditor(
       },
     },
     widgetRules: [
-      createBase64WidgetRule(() => editor),
+      createBase64WidgetRule((): Editor => editor),
     ],
   });
+  /* eslint-enable prefer-const */
 
   // Override getMarkdown to strip internal $$widget placeholders
   const originalGetMarkdown = editor.getMarkdown.bind(editor);

--- a/web_src/js/features/toast-editor.ts
+++ b/web_src/js/features/toast-editor.ts
@@ -1,7 +1,7 @@
 // @ts-expect-error - @toast-ui/editor has type definition issues with package.json exports
 import Editor from '@toast-ui/editor';
 import '@toast-ui/editor/dist/toastui-editor.css';
-import {createBase64WidgetRule} from './comp/base64ImageWidget.ts';
+import {createBase64WidgetRule, installBase64WidgetPatch} from './comp/base64ImageWidget.ts';
 
 export type ToastEditorOptions = {
   height?: string;
@@ -44,9 +44,10 @@ export async function createToastEditor(
   }
 
   // Initialize Toast UI Editor
-  /* eslint-disable prefer-const */
-  let editor: Editor;
-  editor = new Editor({
+  const widgetRules = [
+    createBase64WidgetRule((): Editor => editor),
+  ];
+  const editor: Editor = new Editor({
     el: container,
     height,
     initialEditType,
@@ -61,18 +62,11 @@ export async function createToastEditor(
         textarea.dispatchEvent(new Event('change'));
       },
     },
-    widgetRules: [
-      createBase64WidgetRule((): Editor => editor),
-    ],
+    widgetRules,
   });
-  /* eslint-enable prefer-const */
 
   // Override getMarkdown to strip internal $$widget placeholders
-  const originalGetMarkdown = editor.getMarkdown.bind(editor);
-  editor.getMarkdown = () => {
-    const content = originalGetMarkdown();
-    return content.replace(/\$\$widget\d+\s+(!\[[^\]]*\]\(data:image\/[a-zA-Z+.-]+;base64,[A-Za-z0-9+/=\s]{50,}\))\$\$/g, '$1');
-  };
+  installBase64WidgetPatch(editor);
 
   // Set initial content
   if (textarea.value) {

--- a/web_src/js/features/toast-editor.ts
+++ b/web_src/js/features/toast-editor.ts
@@ -2,6 +2,21 @@
 import Editor from '@toast-ui/editor';
 import '@toast-ui/editor/dist/toastui-editor.css';
 
+const imageIconSvg = `
+<svg class="base64-image-icon" width="12" height="12" viewBox="0 0 16 16" fill="currentColor" style="vertical-align: middle;">
+  <path d="M1.75 2.5a.25.25 0 0 0-.25.25v10.5c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25V2.75a.25.25 0 0 0-.25-.25H1.75zM0 2.75C0 1.784.784 1 1.75 1h12.5c.966 0 1.75.784 1.75 1.75v10.5A1.75 1.75 0 0 1 14.25 15H1.75A1.75 1.75 0 0 1 0 13.25V2.75zm9.5 4.75a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm-7.25 5h11.5a.25.25 0 0 0 .222-.365l-3.5-7a.25.25 0 0 0-.43 0L7.5 10.386l-2.066-3.1a.25.25 0 0 0-.416 0l-3 4.5A.25.25 0 0 0 2.25 12.5z"/>
+</svg>
+`;
+
+function formatBytes(bytes: number, decimals = 1): string {
+  if (bytes === 0) return '0 B';
+  const k = 1024;
+  const dm = Math.max(0, decimals);
+  const sizes = ['B', 'KB', 'MB', 'GB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return `${parseFloat((bytes / (k ** i)).toFixed(dm))} ${sizes[i]}`;
+}
+
 export type ToastEditorOptions = {
   height?: string;
   initialEditType?: 'markdown' | 'wysiwyg';
@@ -58,7 +73,76 @@ export async function createToastEditor(
         textarea.dispatchEvent(new Event('change'));
       },
     },
+    widgetRules: [
+      {
+        rule: /!\[([^\]]*)\]\((data:image\/[a-zA-Z+.-]+;base64,[A-Za-z0-9+/=\s]{50,})\)/,
+        toDOM(text: string) {
+          let isWysiwyg = false;
+          try {
+            if (editor && typeof editor.isWysiwygMode === 'function') {
+              isWysiwyg = editor.isWysiwygMode();
+            }
+          } catch {}
+
+          if (!isWysiwyg) {
+            const activeTab = container.querySelector('.toastui-editor-mode-switch .tab-item.active');
+            if (activeTab && (activeTab.textContent?.includes('Visual') || activeTab.textContent?.includes('WYSIWYG'))) {
+              isWysiwyg = true;
+            }
+          }
+
+          const match = /!\[([^\]]*)\]\((data:image\/[a-zA-Z+.-]+;base64,[A-Za-z0-9+/=\s]+)\)/.exec(text);
+          const altText = match ? match[1] : '';
+          const base64Url = match ? match[2] : '';
+
+          if (isWysiwyg) {
+            const img = document.createElement('img');
+            img.src = base64Url;
+            img.alt = altText || 'Image';
+            img.className = 'base64-wysiwyg-preview';
+            img.style.maxWidth = '100%';
+            return img;
+          }
+
+          const mimeMatch = /^data:(image\/[a-zA-Z+.-]+);base64,/.exec(base64Url);
+          const mimeType = mimeMatch ? mimeMatch[1] : 'image';
+          const extension = mimeType.replace('image/', '').toUpperCase();
+          const sizeBytes = Math.round((base64Url.length - (base64Url.indexOf(',') + 1)) * 0.75);
+          const formattedSize = formatBytes(sizeBytes);
+
+          const el = document.createElement('span');
+          el.className = 'base64-image-widget';
+          el.title = `Alt: ${altText} | Base64 Encoded Image - Click to copy original data URI`;
+          el.innerHTML = `${imageIconSvg} <span>Base64 Image (${extension}, ${formattedSize}${altText ? ` - ${altText}` : ''})</span>`;
+
+          el.addEventListener('click', async (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            try {
+              await navigator.clipboard.writeText(base64Url);
+              const label = el.querySelector('span');
+              if (label) {
+                const originalText = label.textContent;
+                label.textContent = 'Copied to clipboard!';
+                setTimeout(() => {
+                  label.textContent = originalText;
+                }, 2000);
+              }
+            } catch (err) {
+              console.error('Failed to copy to clipboard', err);
+            }
+          });
+        },
+      },
+    ],
   });
+
+  // Override getMarkdown to strip internal $$widget placeholders
+  const originalGetMarkdown = editor.getMarkdown.bind(editor);
+  editor.getMarkdown = () => {
+    const content = originalGetMarkdown();
+    return content.replace(/\$\$widget\d+\s+(!\[[^\]]*\]\(data:image\/[a-zA-Z+.-]+;base64,[A-Za-z0-9+/=\s]{50,}\))\$\$/g, '$1');
+  };
 
   // Set initial content
   if (textarea.value) {

--- a/web_src/js/features/toast-editor.ts
+++ b/web_src/js/features/toast-editor.ts
@@ -132,6 +132,8 @@ export async function createToastEditor(
               console.error('Failed to copy to clipboard', err);
             }
           });
+
+          return el;
         },
       },
     ],

--- a/web_src/js/features/toast-editor.ts
+++ b/web_src/js/features/toast-editor.ts
@@ -44,8 +44,10 @@ export async function createToastEditor(
   }
 
   // Initialize Toast UI Editor
+  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents -- Editor type has issues
+  const editorRef = {current: null as Editor | null};
   const widgetRules = [
-    createBase64WidgetRule((): Editor => editor),
+    createBase64WidgetRule((): Editor => editorRef.current!),
   ];
   const editor: Editor = new Editor({
     el: container,
@@ -57,13 +59,14 @@ export async function createToastEditor(
     toolbarItems,
     events: {
       change: () => {
-        const content = editor.getMarkdown();
+        const content = editorRef.current!.getMarkdown();
         textarea.value = content;
         textarea.dispatchEvent(new Event('change'));
       },
     },
     widgetRules,
   });
+  editorRef.current = editor;
 
   // Override getMarkdown to strip internal $$widget placeholders
   installBase64WidgetPatch(editor);

--- a/web_src/js/features/toast-editor.ts
+++ b/web_src/js/features/toast-editor.ts
@@ -1,21 +1,7 @@
 // @ts-expect-error - @toast-ui/editor has type definition issues with package.json exports
 import Editor from '@toast-ui/editor';
 import '@toast-ui/editor/dist/toastui-editor.css';
-
-const imageIconSvg = `
-<svg class="base64-image-icon" width="12" height="12" viewBox="0 0 16 16" fill="currentColor" style="vertical-align: middle;">
-  <path d="M1.75 2.5a.25.25 0 0 0-.25.25v10.5c0 .138.112.25.25.25h12.5a.25.25 0 0 0 .25-.25V2.75a.25.25 0 0 0-.25-.25H1.75zM0 2.75C0 1.784.784 1 1.75 1h12.5c.966 0 1.75.784 1.75 1.75v10.5A1.75 1.75 0 0 1 14.25 15H1.75A1.75 1.75 0 0 1 0 13.25V2.75zm9.5 4.75a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm-7.25 5h11.5a.25.25 0 0 0 .222-.365l-3.5-7a.25.25 0 0 0-.43 0L7.5 10.386l-2.066-3.1a.25.25 0 0 0-.416 0l-3 4.5A.25.25 0 0 0 2.25 12.5z"/>
-</svg>
-`;
-
-function formatBytes(bytes: number, decimals = 1): string {
-  if (bytes === 0) return '0 B';
-  const k = 1024;
-  const dm = Math.max(0, decimals);
-  const sizes = ['B', 'KB', 'MB', 'GB'];
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
-  return `${parseFloat((bytes / (k ** i)).toFixed(dm))} ${sizes[i]}`;
-}
+import {createBase64WidgetRule} from './comp/base64ImageWidget.ts';
 
 export type ToastEditorOptions = {
   height?: string;
@@ -74,72 +60,7 @@ export async function createToastEditor(
       },
     },
     widgetRules: [
-      {
-        rule: /!\[([^\]]*)\]\((data:image\/[a-zA-Z+.-]+;base64,[A-Za-z0-9+/=\s]{50,})\)/,
-        toDOM(text: string) {
-          let isWysiwyg = false;
-          try {
-            if (editor && typeof editor.isWysiwygMode === 'function') {
-              isWysiwyg = editor.isWysiwygMode();
-            }
-          } catch {}
-
-          if (!isWysiwyg) {
-            const activeTab = container.querySelector('.toastui-editor-mode-switch .tab-item.active');
-            if (activeTab && (activeTab.textContent?.includes('Visual') || activeTab.textContent?.includes('WYSIWYG'))) {
-              isWysiwyg = true;
-            }
-          }
-
-          const match = /!\[([^\]]*)\]\((data:image\/[a-zA-Z+.-]+;base64,[A-Za-z0-9+/=\s]+)\)/.exec(text);
-          const altText = match ? match[1] : '';
-          const base64Url = match ? match[2] : '';
-
-          if (isWysiwyg) {
-            const img = document.createElement('img');
-            img.src = base64Url;
-            img.alt = altText || 'Image';
-            img.className = 'base64-wysiwyg-preview';
-            img.style.maxWidth = '100%';
-            return img;
-          }
-
-          const mimeMatch = /^data:(image\/[a-zA-Z+.-]+);base64,/.exec(base64Url);
-          const mimeType = mimeMatch ? mimeMatch[1] : 'image';
-          const extension = mimeType.replace('image/', '').toUpperCase();
-          const sizeBytes = Math.round((base64Url.length - (base64Url.indexOf(',') + 1)) * 0.75);
-          const formattedSize = formatBytes(sizeBytes);
-
-          const el = document.createElement('span');
-          el.className = 'base64-image-widget';
-          el.title = `Alt: ${altText} | Base64 Encoded Image - Click to copy original data URI`;
-          el.innerHTML = imageIconSvg.trim();
-
-          const label = document.createElement('span');
-          label.textContent = `Base64 Image (${extension}, ${formattedSize}${altText ? ` - ${altText}` : ''})`;
-          el.append(label);
-
-          el.addEventListener('click', async (e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            try {
-              await navigator.clipboard.writeText(base64Url);
-              const label = el.querySelector('span');
-              if (label) {
-                const originalText = label.textContent;
-                label.textContent = 'Copied to clipboard!';
-                setTimeout(() => {
-                  label.textContent = originalText;
-                }, 2000);
-              }
-            } catch (err) {
-              console.error('Failed to copy to clipboard', err);
-            }
-          });
-
-          return el;
-        },
-      },
+      createBase64WidgetRule(() => editor, () => container),
     ],
   });
 


### PR DESCRIPTION
Problem
The Source Editor displays images as base 64 (e.g. data:image/jpeg;base64). This means the user will need to scroll "forever" for each image in a comment or article they are attempting to edit.

Solution:
Frontend JavaScript/TypeScript Components
We will update the Toast UI Editor initialization in both the article editor and comment/issue editors to include the custom widgetRules.

[MODIFY] 
toast-editor.ts
Add utility helpers formatBytes and the Octicon imageIconSvg at the top of the file.
Add widgetRules inside the new Editor(...) options list in createToastEditor to match base64 image URIs (data:image/...;base64,... greater than 50 chars) and replace them with the custom interactive widget.

ToastCommentEditor.ts
Define the identical helper utilities at the top of the file.
Inject the identical widgetRules in the comment/issue editor new Editor(...) options list inside setupEditor.
Custom Stylesheet

repo.custom.css
Append premium CSS styles for .base64-image-widget supporting transitions, active states, light/dark mode variables, and micro-hover animations.

Co-authored by: Opus 4.7 and Gemini 3.5
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/okturtles/forkana/pull/198" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->