### PR TITLE
Closes #220 - fix stale custom overrides

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,12 @@
 # Build stage
 FROM docker.io/library/golang:1.25-alpine3.22 AS build-env
 
+# Default was "direct", but gitea.com blocks CI/datacenter traffic with 403s
+# (e.g. when fetching the gitea.com/gitea/go-xsd-duration replace module),
+# breaking Docker builds. Going through proxy.golang.org avoids hitting
+# gitea.com directly since the proxy serves modules from its cache.
 ARG GOPROXY
-ENV GOPROXY=${GOPROXY:-direct}
+ENV GOPROXY=${GOPROXY:-https://proxy.golang.org,direct}
 
 ARG GITEA_VERSION
 ARG TAGS="sqlite sqlite_unlock_notify"

--- a/Dockerfile.rootless
+++ b/Dockerfile.rootless
@@ -1,8 +1,12 @@
 # Build stage
 FROM docker.io/library/golang:1.25-alpine3.22 AS build-env
 
+# Default was "direct", but gitea.com blocks CI/datacenter traffic with 403s
+# (e.g. when fetching the gitea.com/gitea/go-xsd-duration replace module),
+# breaking Docker builds. Going through proxy.golang.org avoids hitting
+# gitea.com directly since the proxy serves modules from its cache.
 ARG GOPROXY
-ENV GOPROXY=${GOPROXY:-direct}
+ENV GOPROXY=${GOPROXY:-https://proxy.golang.org,direct}
 
 ARG GITEA_VERSION
 ARG TAGS="sqlite sqlite_unlock_notify"

--- a/docker/forkana/DEPLOYMENT_GUIDE.md
+++ b/docker/forkana/DEPLOYMENT_GUIDE.md
@@ -119,8 +119,8 @@ sudo dnf install -y git jq curl
 > skip this step - the deploy user's directories are created there instead.
 
 ```bash
-mkdir -p ~/forkana/{data,data/git,data/custom,config,postgres,compose}
-chmod 0755 ~/forkana/data ~/forkana/data/git ~/forkana/data/custom ~/forkana/config
+mkdir -p ~/forkana/{data,data/git,config,postgres,compose}
+chmod 0755 ~/forkana/data ~/forkana/data/git ~/forkana/config
 ```
 
 </details>
@@ -213,10 +213,9 @@ DEPLOY_USER="forkana-deploy"  # ← replace with your UID 1000 username
 DEPLOY_HOME="$(getent passwd "${DEPLOY_USER}" | cut -d: -f6)"
 
 sudo -Hiu "${DEPLOY_USER}" bash -lc "
-  mkdir -p $DEPLOY_HOME/forkana/{compose,data,data/git,data/custom,config,postgres,images}
+  mkdir -p $DEPLOY_HOME/forkana/{compose,data,data/git,config,postgres,images}
   chmod 0755 $DEPLOY_HOME/forkana/data $DEPLOY_HOME/forkana/data/git \
-             $DEPLOY_HOME/forkana/data/custom $DEPLOY_HOME/forkana/config \
-             $DEPLOY_HOME/forkana/images
+             $DEPLOY_HOME/forkana/config $DEPLOY_HOME/forkana/images
 "
 ```
 

--- a/docker/forkana/Dockerfile
+++ b/docker/forkana/Dockerfile
@@ -95,16 +95,18 @@ COPY --from=build-env --chown=root:root /go/src/code.gitea.io/gitea/environment-
 
 # Bake Forkana custom overrides (options, public, services, templates) into the image.
 # public/ carries custom CSS (content.custom.css, navbar.custom.css, etc.) and images.
-# Placed outside both VOLUME paths (/var/lib/gitea, /etc/gitea) so they survive
-# volume mounts. docker-setup.sh syncs them into GITEA_CUSTOM on every startup.
-COPY --from=build-env --chown=1000:1000 /tmp/custom-defaults/ /usr/local/share/gitea/custom-defaults/
+# Placed outside both VOLUME paths (/var/lib/gitea, /etc/gitea) and used directly
+# as GITEA_CUSTOM, so every deployed image atomically ships its matching
+# overrides. They are intentionally NOT synced into the data volume: a copy
+# there previously went stale and shadowed updated templates on deploy.
+COPY --from=build-env --chown=1000:1000 /tmp/custom-defaults/ /usr/local/share/gitea/custom/
 
 # Run as non-root user (git:git)
 USER 1000:1000
 
 # Environment configuration
 ENV GITEA_WORK_DIR=/var/lib/gitea
-ENV GITEA_CUSTOM=/var/lib/gitea/custom
+ENV GITEA_CUSTOM=/usr/local/share/gitea/custom
 ENV GITEA_TEMP=/tmp/gitea
 ENV TMPDIR=/tmp/gitea
 ENV GITEA_APP_INI=/etc/gitea/app.ini

--- a/docker/forkana/deploy_common.sh
+++ b/docker/forkana/deploy_common.sh
@@ -153,7 +153,6 @@ deploy_run() {
   for dir in \
     "${DEPLOY_DIR}/data" \
     "${DEPLOY_DIR}/data/git" \
-    "${DEPLOY_DIR}/data/custom" \
     "${DEPLOY_DIR}/config" \
     "${DEPLOY_DIR}/postgres"; do
     if [[ ! -d "${dir}" ]]; then

--- a/docker/forkana/usr/local/bin/docker-setup.sh
+++ b/docker/forkana/usr/local/bin/docker-setup.sh
@@ -6,17 +6,9 @@
 mkdir -p ${HOME} && chmod 0700 ${HOME}
 if [ ! -w ${HOME} ]; then echo "${HOME} is not writable"; exit 1; fi
 
-# Prepare custom folder
-mkdir -p ${GITEA_CUSTOM} && chmod 0700 ${GITEA_CUSTOM}
-
-# Sync baked-in custom defaults (options, public, services, templates) into GITEA_CUSTOM.
-# The defaults live outside the volume paths so they survive volume mounts.
-# Uses cp -rn so existing user-modified files are never overwritten.
-CUSTOM_DEFAULTS="/usr/local/share/gitea/custom-defaults"
-if [ -d "${CUSTOM_DEFAULTS}" ] && [ -n "$(find "${CUSTOM_DEFAULTS}" -mindepth 1 -maxdepth 1 -print -quit)" ]; then
-    # Use glob instead of "/." — BusyBox cp -rn silently fails with the dot syntax.
-    cp -rn "${CUSTOM_DEFAULTS}"/* "${GITEA_CUSTOM}/"
-fi
+# GITEA_CUSTOM is baked into the image (see Dockerfile) and points outside the
+# volume paths, so no per-boot sync into the data volume is needed; each image
+# already ships its matching custom overrides.
 
 # Prepare temp folder
 mkdir -p ${GITEA_TEMP} && chmod 0700 ${GITEA_TEMP}


### PR DESCRIPTION
Serve baked-in custom overrides directly from the image instead of syncing them into the data volume, where a stale copy shadowed updated templates on deploy instead of a never-overwritten volume copy

This PR also fixes an issue that can sometimes happen when building the project via the Dockerfiles due to dependencies being pulled direct instead of via a proxy (see [458b528](https://github.com/okTurtles/forkana/pull/221/commits/458b5282fb7ffad1699ff768c584ff3e31657ed8)).

Closes #220.

## AI Disclosure

Assisted with Fable 5.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/okturtles/forkana/pull/221" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->