### PR TITLE
feat: replace theme dropdown with visual theme preview selector in apparence settings

### DIFF
--- a/docker/forkana/etc/templates/app.ini
+++ b/docker/forkana/etc/templates/app.ini
@@ -96,3 +96,8 @@ ENABLED = false
 
 [lfs]
 PATH = $GITEA_WORK_DIR/git/lfs
+
+[ui]
+DEFAULT_THEME = gitea-light
+THEMES = gitea-light,gitea-dark,gitea-auto,gitea-light-protanopia-deuteranopia,gitea-dark-protanopia-deuteranopia,gitea-auto-protanopia-deuteranopia
+EXPLORE_PAGING_DEFAULT_SORT = alphabetically

--- a/services/webtheme/webtheme.go
+++ b/services/webtheme/webtheme.go
@@ -134,21 +134,24 @@ func initThemes() {
 		}
 	}
 	if len(setting.UI.Themes) > 0 {
-		allowedThemes := container.SetOf(setting.UI.Themes...)
+		themeMap := make(map[string]*ThemeMetaInfo)
 		for _, theme := range foundThemes {
-			if allowedThemes.Contains(theme.InternalName) {
+			themeMap[theme.InternalName] = theme
+		}
+		for _, themeName := range setting.UI.Themes {
+			if theme, ok := themeMap[themeName]; ok {
 				availableThemes = append(availableThemes, theme)
 			}
 		}
 	} else {
 		availableThemes = foundThemes
+		sort.Slice(availableThemes, func(i, j int) bool {
+			if availableThemes[i].InternalName == setting.UI.DefaultTheme {
+				return true
+			}
+			return availableThemes[i].DisplayName < availableThemes[j].DisplayName
+		})
 	}
-	sort.Slice(availableThemes, func(i, j int) bool {
-		if availableThemes[i].InternalName == setting.UI.DefaultTheme {
-			return true
-		}
-		return availableThemes[i].DisplayName < availableThemes[j].DisplayName
-	})
 	if len(availableThemes) == 0 {
 		setting.LogStartupProblem(1, log.ERROR, "No theme candidate in asset files, but Gitea requires there should be at least one usable theme")
 		availableThemes = []*ThemeMetaInfo{defaultThemeMetaInfoByInternalName(setting.UI.DefaultTheme)}

--- a/templates/user/settings/appearance.tmpl
+++ b/templates/user/settings/appearance.tmpl
@@ -1,4 +1,23 @@
 {{template "user/settings/layout_head" (dict "ctxData" . "pageClass" "user settings")}}
+
+{{define "theme-preview-svg"}}
+<svg width="247" height="128" viewBox="0 0 247 128" fill="none" xmlns="http://www.w3.org/2000/svg" {{if .class}}class="{{.class}}"{{end}}>
+	<path d="M243 0.5C244.933 0.5 246.5 2.067 246.5 4V124C246.5 125.933 244.933 127.5 243 127.5H4C2.06701 127.5 0.5 125.933 0.5 124V4C0.5 2.067 2.067 0.5 4 0.5H243Z" class="svg-nav-bg"/>
+	<rect x="24" y="28" width="48" height="9" rx="4.5" class="svg-secondary"/>
+	<rect x="24" y="48" width="48" height="9" rx="4.5" class="svg-secondary"/>
+	<rect x="24" y="68" width="48" height="9" rx="4.5" class="svg-secondary"/>
+	<rect x="24" y="88" width="48" height="9" rx="4.5" class="svg-secondary"/>
+	<path d="M86 32C86 29.7909 87.7909 28 90 28H246V123C246 125.209 244.209 127 242 127H86V32Z" class="svg-box-body"/>
+	<!-- Diff indicators to show colorblind variants -->
+	<rect x="106" y="52" width="120" height="12" rx="2" class="svg-diff-removed"/>
+	<rect x="106" y="72" width="120" height="12" rx="2" class="svg-diff-added"/>
+	<circle cx="12.5" cy="32.5" r="4.5" class="svg-primary"/>
+	<circle cx="12.5" cy="52.5" r="4.5" class="svg-primary"/>
+	<circle cx="12.5" cy="72.5" r="4.5" class="svg-primary"/>
+	<rect x="8" y="8.00002" width="64" height="9" rx="4.5" class="svg-secondary"/>
+	<circle cx="12.5" cy="92.5" r="4.5" class="svg-primary"/>
+</svg>
+{{end}}
 	<div class="user-setting-content">
 
 		<!-- Theme -->
@@ -6,7 +25,7 @@
 			{{ctx.Locale.Tr "settings.manage_themes"}}
 		</h4>
 		<div class="ui attached segment">
-			<form class="ui form" action="{{.Link}}/theme" method="post">
+			<form class="ui form ignore-dirty" action="{{.Link}}/theme" method="post" id="theme-selector-form">
 				{{.CsrfTokenHtml}}
 				<div class="field">
 					{{ctx.Locale.Tr "settings.theme_desc"}}
@@ -16,14 +35,27 @@
 				</div>
 				<div class="field">
 					<label>{{ctx.Locale.Tr "settings.ui"}}</label>
-					<select name="theme" class="ui dropdown">
+					<div class="theme-list">
 						{{range $theme := .AllThemes}}
-						<option value="{{$theme.InternalName}}" {{Iif (eq $.SignedUser.Theme $theme.InternalName) "selected"}}>{{$theme.DisplayName}}</option>
+						{{$isAuto := StringUtils.HasPrefix $theme.InternalName "gitea-auto"}}
+						<fieldset class="theme-fieldset">
+							<label for="theme_{{$theme.InternalName}}" class="theme-label">
+								<input type="radio" class="theme-radio" name="theme" value="{{$theme.InternalName}}" id="theme_{{$theme.InternalName}}" {{if eq $.SignedUser.Theme $theme.InternalName}}checked{{end}} onchange="document.getElementById('theme-selector-form').submit()">
+								<div class="c-color" data-theme="{{$theme.InternalName}}">
+									{{if $isAuto}}
+									<div class="c-combined-color">
+										{{template "theme-preview-svg" (dict "class" "svg-light")}}
+										{{template "theme-preview-svg" (dict "class" "svg-dark")}}
+									</div>
+									{{else}}
+										{{template "theme-preview-svg" (dict "class" "")}}
+									{{end}}
+								</div>
+								<span class="theme-name">{{$theme.DisplayName}}</span>
+							</label>
+						</fieldset>
 						{{end}}
-					</select>
-				</div>
-				<div class="field">
-					<button class="ui primary button">{{ctx.Locale.Tr "settings.update_theme"}}</button>
+					</div>
 				</div>
 			</form>
 		</div>

--- a/templates/user/settings/appearance.tmpl
+++ b/templates/user/settings/appearance.tmpl
@@ -34,11 +34,11 @@
 					</a>
 				</div>
 				<div class="field">
-					<label>{{ctx.Locale.Tr "settings.ui"}}</label>
-					<div class="theme-list">
-						{{range $theme := .AllThemes}}
-						{{$isAuto := StringUtils.HasPrefix $theme.InternalName "gitea-auto"}}
-						<fieldset class="theme-fieldset">
+					<fieldset class="theme-list-fieldset">
+						<legend class="theme-list-legend">{{ctx.Locale.Tr "settings.ui"}}</legend>
+						<div class="theme-list">
+							{{range $theme := .AllThemes}}
+							{{$isAuto := StringUtils.HasPrefix $theme.InternalName "gitea-auto"}}
 							<label for="theme_{{$theme.InternalName}}" class="theme-label">
 								<input type="radio" class="theme-radio" name="theme" value="{{$theme.InternalName}}" id="theme_{{$theme.InternalName}}" {{if eq $.SignedUser.Theme $theme.InternalName}}checked{{end}}>
 								<div class="c-color" data-theme="{{$theme.InternalName}}">
@@ -53,9 +53,9 @@
 								</div>
 								<span class="theme-name">{{$theme.DisplayName}}</span>
 							</label>
-						</fieldset>
-						{{end}}
-					</div>
+							{{end}}
+						</div>
+					</fieldset>
 				</div>
 				{{/* No-JS / keyboard fallback: JavaScript hides this and auto-submits on change instead. */}}
 				<div class="field theme-submit-fallback">

--- a/templates/user/settings/appearance.tmpl
+++ b/templates/user/settings/appearance.tmpl
@@ -57,6 +57,10 @@
 						{{end}}
 					</div>
 				</div>
+				{{/* No-JS / keyboard fallback: JavaScript hides this and auto-submits on change instead. */}}
+				<div class="field theme-submit-fallback">
+					<button class="ui primary button">{{ctx.Locale.Tr "settings.update_theme"}}</button>
+				</div>
 			</form>
 		</div>
 

--- a/templates/user/settings/appearance.tmpl
+++ b/templates/user/settings/appearance.tmpl
@@ -40,7 +40,7 @@
 						{{$isAuto := StringUtils.HasPrefix $theme.InternalName "gitea-auto"}}
 						<fieldset class="theme-fieldset">
 							<label for="theme_{{$theme.InternalName}}" class="theme-label">
-								<input type="radio" class="theme-radio" name="theme" value="{{$theme.InternalName}}" id="theme_{{$theme.InternalName}}" {{if eq $.SignedUser.Theme $theme.InternalName}}checked{{end}} onchange="document.getElementById('theme-selector-form').submit()">
+								<input type="radio" class="theme-radio" name="theme" value="{{$theme.InternalName}}" id="theme_{{$theme.InternalName}}" {{if eq $.SignedUser.Theme $theme.InternalName}}checked{{end}}>
 								<div class="c-color" data-theme="{{$theme.InternalName}}">
 									{{if $isAuto}}
 									<div class="c-combined-color">

--- a/templates/user/settings/appearance.tmpl
+++ b/templates/user/settings/appearance.tmpl
@@ -1,8 +1,10 @@
 {{template "user/settings/layout_head" (dict "ctxData" . "pageClass" "user settings")}}
 
-{{/* The preview shape is defined once as a <symbol>; each card references it via <use>.
-     Fills are inline so they survive the <use> shadow tree, resolving the --preview-*
-     custom properties inherited from each card's .c-color wrapper. */}}
+{{/*
+	The preview shape is defined once as a <symbol>; each card references it via <use>.
+	Fills are inline so they survive the <use> shadow tree, resolving the per-card
+	--preview-* custom properties inherited from each .c-color wrapper.
+*/}}
 {{define "theme-preview-sprite"}}
 <svg class="theme-preview-sprite" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
 	<symbol id="theme-preview-symbol" viewBox="0 0 247 128">

--- a/templates/user/settings/appearance.tmpl
+++ b/templates/user/settings/appearance.tmpl
@@ -1,22 +1,30 @@
 {{template "user/settings/layout_head" (dict "ctxData" . "pageClass" "user settings")}}
 
-{{define "theme-preview-svg"}}
-<svg width="247" height="128" viewBox="0 0 247 128" fill="none" xmlns="http://www.w3.org/2000/svg" {{if .class}}class="{{.class}}"{{end}}>
-	<path d="M243 0.5C244.933 0.5 246.5 2.067 246.5 4V124C246.5 125.933 244.933 127.5 243 127.5H4C2.06701 127.5 0.5 125.933 0.5 124V4C0.5 2.067 2.067 0.5 4 0.5H243Z" class="svg-nav-bg"/>
-	<rect x="24" y="28" width="48" height="9" rx="4.5" class="svg-secondary"/>
-	<rect x="24" y="48" width="48" height="9" rx="4.5" class="svg-secondary"/>
-	<rect x="24" y="68" width="48" height="9" rx="4.5" class="svg-secondary"/>
-	<rect x="24" y="88" width="48" height="9" rx="4.5" class="svg-secondary"/>
-	<path d="M86 32C86 29.7909 87.7909 28 90 28H246V123C246 125.209 244.209 127 242 127H86V32Z" class="svg-box-body"/>
-	<!-- Diff indicators to show colorblind variants -->
-	<rect x="106" y="52" width="120" height="12" rx="2" class="svg-diff-removed"/>
-	<rect x="106" y="72" width="120" height="12" rx="2" class="svg-diff-added"/>
-	<circle cx="12.5" cy="32.5" r="4.5" class="svg-primary"/>
-	<circle cx="12.5" cy="52.5" r="4.5" class="svg-primary"/>
-	<circle cx="12.5" cy="72.5" r="4.5" class="svg-primary"/>
-	<rect x="8" y="8.00002" width="64" height="9" rx="4.5" class="svg-secondary"/>
-	<circle cx="12.5" cy="92.5" r="4.5" class="svg-primary"/>
+{{/* The preview shape is defined once as a <symbol>; each card references it via <use>.
+     Fills are inline so they survive the <use> shadow tree, resolving the --preview-*
+     custom properties inherited from each card's .c-color wrapper. */}}
+{{define "theme-preview-sprite"}}
+<svg class="theme-preview-sprite" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
+	<symbol id="theme-preview-symbol" viewBox="0 0 247 128">
+		<path d="M243 0.5C244.933 0.5 246.5 2.067 246.5 4V124C246.5 125.933 244.933 127.5 243 127.5H4C2.06701 127.5 0.5 125.933 0.5 124V4C0.5 2.067 2.067 0.5 4 0.5H243Z" style="fill:var(--preview-nav-bg)"/>
+		<rect x="24" y="28" width="48" height="9" rx="4.5" style="fill:var(--preview-secondary)"/>
+		<rect x="24" y="48" width="48" height="9" rx="4.5" style="fill:var(--preview-secondary)"/>
+		<rect x="24" y="68" width="48" height="9" rx="4.5" style="fill:var(--preview-secondary)"/>
+		<rect x="24" y="88" width="48" height="9" rx="4.5" style="fill:var(--preview-secondary)"/>
+		<path d="M86 32C86 29.7909 87.7909 28 90 28H246V123C246 125.209 244.209 127 242 127H86V32Z" style="fill:var(--preview-box-body)"/>
+		<rect x="106" y="52" width="120" height="12" rx="2" style="fill:var(--preview-diff-removed)"/>
+		<rect x="106" y="72" width="120" height="12" rx="2" style="fill:var(--preview-diff-added)"/>
+		<circle cx="12.5" cy="32.5" r="4.5" style="fill:var(--preview-primary)"/>
+		<circle cx="12.5" cy="52.5" r="4.5" style="fill:var(--preview-primary)"/>
+		<circle cx="12.5" cy="72.5" r="4.5" style="fill:var(--preview-primary)"/>
+		<rect x="8" y="8.00002" width="64" height="9" rx="4.5" style="fill:var(--preview-secondary)"/>
+		<circle cx="12.5" cy="92.5" r="4.5" style="fill:var(--preview-primary)"/>
+	</symbol>
 </svg>
+{{end}}
+
+{{define "theme-preview-svg"}}
+<svg viewBox="0 0 247 128" aria-hidden="true" {{if .class}}class="{{.class}}"{{end}}><use href="#theme-preview-symbol"/></svg>
 {{end}}
 	<div class="user-setting-content">
 
@@ -25,6 +33,7 @@
 			{{ctx.Locale.Tr "settings.manage_themes"}}
 		</h4>
 		<div class="ui attached segment">
+			{{template "theme-preview-sprite" .}}
 			<form class="ui form ignore-dirty" action="{{.Link}}/theme" method="post" id="theme-selector-form">
 				{{.CsrfTokenHtml}}
 				<div class="field">

--- a/web_src/css/user.css
+++ b/web_src/css/user.css
@@ -146,3 +146,131 @@
 .notifications-item:hover .notifications-updated {
   display: none;
 }
+
+/* Settings: Theme Selector */
+.theme-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 1.5rem;
+  margin-top: 1rem;
+}
+
+.theme-fieldset {
+  border: none;
+  margin: 0;
+  padding: 0;
+}
+
+.theme-label {
+  display: grid;
+  grid-template-areas: 
+    "color color"
+    "radio name";
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  column-gap: 0.5rem;
+  row-gap: 0.5rem;
+  cursor: pointer;
+}
+
+.theme-label .c-color {
+  grid-area: color;
+  transition: transform 250ms cubic-bezier(0.4, 0.25, 0.3, 1), border-color 250ms ease;
+  border: 2px solid var(--color-secondary);
+  border-radius: 6px;
+  overflow: hidden;
+  position: relative;
+  background: var(--preview-nav-bg); /* Default fallback */
+}
+
+.theme-label:hover .c-color {
+  transform: scale(1.05);
+  border-color: var(--color-primary);
+}
+
+.theme-label .theme-radio {
+  grid-area: radio;
+  margin: 0;
+}
+
+.theme-label .theme-name {
+  grid-area: name;
+}
+
+.theme-radio:checked + .c-color {
+  border-color: var(--color-primary);
+}
+
+/* Base variables for SVG previews */
+.c-color {
+  --preview-nav-bg: #f6f8fa;
+  --preview-secondary: #d0d7de;
+  --preview-box-body: #ffffff;
+  --preview-primary: #4E40FA;
+  --preview-diff-removed: #FFE7D1;
+  --preview-diff-added: #E5E9FF;
+}
+
+.c-color[data-theme*="protanopia"] {
+  --preview-diff-removed: #ffb77c40;
+  --preview-diff-added: #54aeff40;
+}
+
+.c-color[data-theme*="dark"] {
+  --preview-nav-bg: #161b22;
+  --preview-secondary: #30363d;
+  --preview-box-body: #1b1f23;
+  --preview-primary: #4E40FA;
+  --preview-diff-removed: #f851491a;
+  --preview-diff-added: #388bfd1a;
+}
+
+.c-color[data-theme*="dark"][data-theme*="protanopia"] {
+  --preview-diff-removed: #ff8c004d;
+  --preview-diff-added: #4d94ff4d;
+}
+
+/* For Auto, .c-color will have both light and dark. */
+.c-combined-color {
+  position: relative;
+  display: flex;
+}
+.c-combined-color .svg-light {
+  clip-path: polygon(0 0, 50% 0, 50% 100%, 0 100%);
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+}
+.c-combined-color .svg-dark {
+  clip-path: polygon(50% 0, 100% 0, 100% 100%, 50% 100%);
+  width: 100%;
+}
+
+/* Override variables for the dark half in auto theme */
+.c-combined-color .svg-dark {
+  --preview-nav-bg: #161b22;
+  --preview-secondary: #30363d;
+  --preview-box-body: #1b1f23;
+  --preview-primary: #4E40FA;
+  --preview-diff-removed: #f851491a;
+  --preview-diff-added: #388bfd1a;
+}
+.c-color[data-theme*="protanopia"] .svg-dark {
+  --preview-diff-removed: #ff8c004d;
+  --preview-diff-added: #4d94ff4d;
+}
+
+/* Apply variables to SVG */
+.c-color svg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.svg-nav-bg { fill: var(--preview-nav-bg); }
+.svg-secondary { fill: var(--preview-secondary); }
+.svg-box-body { fill: var(--preview-box-body); }
+.svg-primary { fill: var(--preview-primary); }
+.svg-diff-removed { fill: var(--preview-diff-removed); }
+.svg-diff-added { fill: var(--preview-diff-added); }

--- a/web_src/css/user.css
+++ b/web_src/css/user.css
@@ -150,9 +150,15 @@
 /* Settings: Theme Selector */
 .theme-list {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  grid-template-columns: repeat(3, 1fr);
   gap: 1.5rem;
   margin-top: 1rem;
+}
+
+@media (max-width: 767.98px) {
+  .theme-list {
+    grid-template-columns: 1fr;
+  }
 }
 
 .theme-list-fieldset {

--- a/web_src/css/user.css
+++ b/web_src/css/user.css
@@ -173,13 +173,12 @@
 
 .theme-label {
   display: grid;
-  grid-template-areas: 
+  grid-template-areas:
     "color color"
     "radio name";
   grid-template-columns: auto 1fr;
   align-items: center;
-  column-gap: 0.5rem;
-  row-gap: 0.5rem;
+  gap: 0.5rem;
   cursor: pointer;
 }
 
@@ -283,16 +282,11 @@
   overflow: hidden;
 }
 
-/* Apply variables to SVG */
+/* The preview <svg> wrappers fill their card; the symbol's shapes carry their own
+   inline fills, so no global .svg-* fill classes are needed (they'd also be too
+   generic and risk colliding with other SVGs on the page). */
 .c-color svg {
   display: block;
   width: 100%;
   height: auto;
 }
-
-.svg-nav-bg { fill: var(--preview-nav-bg); }
-.svg-secondary { fill: var(--preview-secondary); }
-.svg-box-body { fill: var(--preview-box-body); }
-.svg-primary { fill: var(--preview-primary); }
-.svg-diff-removed { fill: var(--preview-diff-removed); }
-.svg-diff-added { fill: var(--preview-diff-added); }

--- a/web_src/css/user.css
+++ b/web_src/css/user.css
@@ -201,36 +201,44 @@
   border-color: var(--color-primary);
 }
 
-/* Base variables for SVG previews */
+/* Preview palettes — values mirror each theme's real tokens in
+   web_src/css/themes/theme-*.css. Only the active theme's CSS variables are
+   loaded at runtime, so the per-theme values are inlined here (keyed by
+   data-theme) instead of referencing var(--color-*), which would resolve to the
+   currently active theme and make every card look identical.
+   gitea-light also serves as the fallback and the light half of gitea-auto. */
 .c-color {
-  --preview-nav-bg: #f6f8fa;
+  --preview-nav-bg: #f6f7fa;
   --preview-secondary: #d0d7de;
   --preview-box-body: #ffffff;
-  --preview-primary: #4E40FA;
-  --preview-diff-removed: #FFE7D1;
-  --preview-diff-added: #E5E9FF;
+  --preview-primary: #4183c4;
+  --preview-diff-removed: #ffeef0;
+  --preview-diff-added: #e6ffed;
 }
 
-.c-color[data-theme*="protanopia"] {
-  --preview-diff-removed: #ffb77c40;
-  --preview-diff-added: #54aeff40;
+.c-color[data-theme="gitea-light-protanopia-deuteranopia"],
+.c-color[data-theme="gitea-auto-protanopia-deuteranopia"] {
+  --preview-diff-removed: #fff1e580;
+  --preview-diff-added: #ddf4ff80;
 }
 
-.c-color[data-theme*="dark"] {
-  --preview-nav-bg: #161b22;
-  --preview-secondary: #30363d;
-  --preview-box-body: #1b1f23;
-  --preview-primary: #4E40FA;
-  --preview-diff-removed: #f851491a;
-  --preview-diff-added: #388bfd1a;
+.c-color[data-theme="gitea-dark"] {
+  --preview-nav-bg: #16191d;
+  --preview-secondary: #3b444c;
+  --preview-box-body: #14171a;
+  --preview-diff-removed: #301e1e;
+  --preview-diff-added: #203224;
 }
 
-.c-color[data-theme*="dark"][data-theme*="protanopia"] {
-  --preview-diff-removed: #ff8c004d;
-  --preview-diff-added: #4d94ff4d;
+.c-color[data-theme="gitea-dark-protanopia-deuteranopia"] {
+  --preview-nav-bg: #16191d;
+  --preview-secondary: #3b444c;
+  --preview-box-body: #14171a;
+  --preview-diff-removed: #c8622120;
+  --preview-diff-added: #1979fd20;
 }
 
-/* For Auto, .c-color will have both light and dark. */
+/* For Auto, .c-color will have both light and dark halves. */
 .c-combined-color {
   position: relative;
   display: flex;
@@ -242,23 +250,19 @@
   left: 0;
   width: 100%;
 }
+/* The dark half of the auto previews uses the dark theme's tokens. */
 .c-combined-color .svg-dark {
   clip-path: polygon(50% 0, 100% 0, 100% 100%, 50% 100%);
   width: 100%;
+  --preview-nav-bg: #16191d;
+  --preview-secondary: #3b444c;
+  --preview-box-body: #14171a;
+  --preview-diff-removed: #301e1e;
+  --preview-diff-added: #203224;
 }
-
-/* Override variables for the dark half in auto theme */
-.c-combined-color .svg-dark {
-  --preview-nav-bg: #161b22;
-  --preview-secondary: #30363d;
-  --preview-box-body: #1b1f23;
-  --preview-primary: #4E40FA;
-  --preview-diff-removed: #f851491a;
-  --preview-diff-added: #388bfd1a;
-}
-.c-color[data-theme*="protanopia"] .svg-dark {
-  --preview-diff-removed: #ff8c004d;
-  --preview-diff-added: #4d94ff4d;
+.c-color[data-theme="gitea-auto-protanopia-deuteranopia"] .svg-dark {
+  --preview-diff-removed: #c8622120;
+  --preview-diff-added: #1979fd20;
 }
 
 /* Apply variables to SVG */

--- a/web_src/css/user.css
+++ b/web_src/css/user.css
@@ -155,10 +155,20 @@
   margin-top: 1rem;
 }
 
-.theme-fieldset {
+.theme-list-fieldset {
   border: none;
   margin: 0;
   padding: 0;
+  min-inline-size: 0; /* let the fieldset shrink so the grid can size its columns */
+}
+
+/* Mirror the Fomantic `.field > label` appearance for the group legend. */
+.theme-list-legend {
+  display: block;
+  margin: 0 0 0.28571429rem;
+  padding: 0;
+  font-size: 0.92857143em;
+  font-weight: var(--font-weight-medium);
 }
 
 .theme-label {

--- a/web_src/css/user.css
+++ b/web_src/css/user.css
@@ -210,17 +210,18 @@
   border-color: var(--color-primary);
 }
 
-/* Preview palettes — values mirror each theme's real tokens in
-   web_src/css/themes/theme-*.css. Only the active theme's CSS variables are
-   loaded at runtime, so the per-theme values are inlined here (keyed by
-   data-theme) instead of referencing var(--color-*), which would resolve to the
-   currently active theme and make every card look identical.
+/* Preview palettes. The settings page only loads the *active* theme's stylesheet
+   (templates/base/head_style.tmpl), so var(--color-*) resolves to the active theme
+   for every card — it can only be used for tokens that are identical across all
+   themes. --color-primary is theme-invariant (#4183c4 everywhere), so the preview
+   reads it live; the theme-varying tokens (nav-bg, secondary, box-body, diff colors)
+   are snapshotted here per theme from web_src/css/themes/theme-*.css.
    gitea-light also serves as the fallback and the light half of gitea-auto. */
 .c-color {
   --preview-nav-bg: #f6f7fa;
   --preview-secondary: #d0d7de;
   --preview-box-body: #ffffff;
-  --preview-primary: #4183c4;
+  --preview-primary: var(--color-primary);
   --preview-diff-removed: #ffeef0;
   --preview-diff-added: #e6ffed;
 }

--- a/web_src/css/user.css
+++ b/web_src/css/user.css
@@ -275,6 +275,14 @@
   --preview-diff-added: #1979fd20;
 }
 
+/* The shared <symbol> sprite is referenced via <use> and never rendered itself. */
+.theme-preview-sprite {
+  position: absolute;
+  width: 0;
+  height: 0;
+  overflow: hidden;
+}
+
 /* Apply variables to SVG */
 .c-color svg {
   display: block;

--- a/web_src/js/features/user-settings.ts
+++ b/web_src/js/features/user-settings.ts
@@ -1,6 +1,19 @@
 import {hideElem, showElem} from '../utils/dom.ts';
 
+// initUserThemeSelector wires the appearance-settings theme cards to submit the form
+// when a theme is picked. Done here with a delegated listener rather than an inline
+// onchange handler so it follows the codebase convention and survives a strict CSP.
+function initUserThemeSelector() {
+  const form = document.querySelector<HTMLFormElement>('#theme-selector-form');
+  if (!form) return;
+  form.addEventListener('change', (e) => {
+    if ((e.target as HTMLElement).matches('.theme-radio')) form.requestSubmit();
+  });
+}
+
 export function initUserSettings() {
+  initUserThemeSelector();
+
   if (!document.querySelector('.user.settings.profile')) return;
 
   const usernameInput = document.querySelector<HTMLInputElement>('#username');

--- a/web_src/js/features/user-settings.ts
+++ b/web_src/js/features/user-settings.ts
@@ -6,6 +6,9 @@ import {hideElem, showElem} from '../utils/dom.ts';
 function initUserThemeSelector() {
   const form = document.querySelector<HTMLFormElement>('#theme-selector-form');
   if (!form) return;
+  // Progressive enhancement: with JS we auto-submit on change, so the explicit
+  // submit button (the no-JS / keyboard fallback) is redundant — hide it.
+  hideElem(form.querySelector('.theme-submit-fallback'));
   form.addEventListener('change', (e) => {
     if ((e.target as HTMLElement).matches('.theme-radio')) form.requestSubmit();
   });


### PR DESCRIPTION
Problem:
The theme selector doesn't look very good

Solution:
Use SVG with actual colour for user to select their preferred theme

Co written with Gemini 3.1 Pro (high) and opus 4.8
