### PR TITLE
refactor: remove redundant merge information text from pull request view

### DIFF
--- a/custom/options/locale/locale_en-US.ini
+++ b/custom/options/locale/locale_en-US.ini
@@ -1996,7 +1996,6 @@ pulls.merged = Merged
 pulls.merged_success = Change request successfully merged and closed
 pulls.closed = Change request closed
 pulls.manually_merged = Manually merged
-pulls.merged_info_text = The branch %s can now be deleted.
 pulls.is_closed = The change request has been closed.
 pulls.title_wip_desc = `<a href="#">Start the title with <strong>%s</strong></a> to prevent the change request from being merged accidentally.`
 pulls.cannot_merge_work_in_progress = This change request is marked as a work in progress.

--- a/custom/templates/repo/issue/view_content/pull_merge_box.tmpl
+++ b/custom/templates/repo/issue/view_content/pull_merge_box.tmpl
@@ -42,7 +42,7 @@
 			{{if .Issue.PullRequest.HasMerged}}
 				<div class="item item-section text tw-flex-1">
 					<div class="item-section-left">
-						<h3 class="tw-mb-2">
+						<h3>
 							{{ctx.Locale.Tr "repo.pulls.merged_success"}}
 						</h3>
 					</div>

--- a/custom/templates/repo/issue/view_content/pull_merge_box.tmpl
+++ b/custom/templates/repo/issue/view_content/pull_merge_box.tmpl
@@ -45,9 +45,6 @@
 						<h3 class="tw-mb-2">
 							{{ctx.Locale.Tr "repo.pulls.merged_success"}}
 						</h3>
-						<div class="merge-section-info">
-							{{ctx.Locale.Tr "repo.pulls.merged_info_text" (HTMLFormat "<code>%s</code>" .HeadTarget)}}
-						</div>
 					</div>
 				</div>
 			{{else if .Issue.IsClosed}}


### PR DESCRIPTION
Closes #166
Issue: The custom template unconditionally renders "repo.pulls.merged_info_text", which in the custom locale says "The branch %s can now be deleted." — shown after every merge, with no condition on whether the branch is actually deletable.

Here's exactly what's still broken:
custom/templates/repo/issue/view_content/pull_merge_box.tmpl:48-50:
```
  <div class="merge-section-info">
      {{ctx.Locale.Tr "repo.pulls.merged_info_text" (HTMLFormat "<code>%s</code>" .HeadTarget)}}
  </div>
```

This renders unconditionally after every merge. Since branches are always auto-deleted on this project, it's always wrong.

The fix is simple — remove those 3 lines from the template (the locale key can stay, it's harmless). The comment on issue #187 that said "fixed in #166" was premature; only half the issue was addressed.

Co-author with Claude opus 4.8