### PR TITLE
Fix/article image attachments

### DIFF
--- a/custom/options/locale/locale_en-US.ini
+++ b/custom/options/locale/locale_en-US.ini
@@ -1425,6 +1425,7 @@ editor.cannot_edit_too_large_file = The file is too large to be edited.
 editor.file_too_large_to_write = The file size exceeds the limit of %d MB and cannot be saved.
 editor.file_too_large = File "%s" exceeds the limit of %d MB and cannot be saved.
 editor.image_read_failed = Failed to read the image file.
+editor.image_upload_failed = Failed to upload the image file.
 editor.cannot_edit_non_text_files = Binary files cannot be edited in the web interface.
 editor.file_not_editable_hint = But you can still rename or move it.
 editor.edit_this_file = Edit File

--- a/custom/templates/repo/editor/edit.tmpl
+++ b/custom/templates/repo/editor/edit.tmpl
@@ -29,7 +29,8 @@
 					<div class="tw-p-0">
 						<textarea id="edit_area" name="content" class="tw-hidden" data-id="repo-{{.Repository.Name}}-{{.TreePath}}"
 							data-previewable-extensions="{{.PreviewableExtensions}}"
-							data-line-wrap-extensions="{{.LineWrapExtensions}}">{{.FileContent}}</textarea>
+							data-line-wrap-extensions="{{.LineWrapExtensions}}"
+							data-attachment-upload-url="{{.RepoLink}}/editor-attachments">{{.FileContent}}</textarea>
 						<div class="editor-loading is-loading"></div>
 						<div id="toast-editor-container" style="min-height: 500px;"></div>
 					</div>

--- a/custom/templates/repo/editor/edit.tmpl
+++ b/custom/templates/repo/editor/edit.tmpl
@@ -30,7 +30,7 @@
 						<textarea id="edit_area" name="content" class="tw-hidden" data-id="repo-{{.Repository.Name}}-{{.TreePath}}"
 							data-previewable-extensions="{{.PreviewableExtensions}}"
 							data-line-wrap-extensions="{{.LineWrapExtensions}}"
-							data-attachment-upload-url="{{.RepoLink}}/editor-attachments">{{.FileContent}}</textarea>
+							{{if .IsAttachmentEnabled}}data-attachment-upload-url="{{.RepoLink}}/editor-attachments"{{end}}>{{.FileContent}}</textarea>
 						<div class="editor-loading is-loading"></div>
 						<div id="toast-editor-container" style="min-height: 500px;"></div>
 					</div>

--- a/custom/templates/repo/editor/edit.tmpl
+++ b/custom/templates/repo/editor/edit.tmpl
@@ -30,7 +30,8 @@
 						<textarea id="edit_area" name="content" class="tw-hidden" data-id="repo-{{.Repository.Name}}-{{.TreePath}}"
 							data-previewable-extensions="{{.PreviewableExtensions}}"
 							data-line-wrap-extensions="{{.LineWrapExtensions}}"
-							{{if .IsAttachmentEnabled}}data-attachment-upload-url="{{.RepoLink}}/editor-attachments"{{end}}>{{.FileContent}}</textarea>
+							data-raw-file-url="{{.RepoOperationsLink}}/raw/{{.RefTypeNameSubURL}}/{{.TreePath | PathEscapeSegments}}"
+							{{if .IsAttachmentEnabled}}data-attachment-upload-url="{{.RepoOperationsLink}}/editor-attachments"{{end}}>{{.FileContent}}</textarea>
 						<div class="editor-loading is-loading"></div>
 						<div id="toast-editor-container" style="min-height: 500px;"></div>
 					</div>

--- a/custom/templates/repo/pulls/edit.tmpl
+++ b/custom/templates/repo/pulls/edit.tmpl
@@ -13,7 +13,7 @@
 
 				<div class="field">
 					<div class="tw-p-0">
-						<textarea id="edit_area" name="content" class="tw-hidden" data-id="repo-{{.Repository.Name}}-{{.ReadmeTreePath}}">{{.FileContent}}</textarea>
+						<textarea id="edit_area" name="content" class="tw-hidden" data-id="repo-{{.Repository.Name}}-{{.ReadmeTreePath}}" data-attachment-upload-url="{{.RepoLink}}/editor-attachments">{{.FileContent}}</textarea>
 						<div class="editor-loading is-loading"></div>
 						<div id="toast-editor-container" style="min-height: 500px;"></div>
 					</div>

--- a/custom/templates/repo/pulls/edit.tmpl
+++ b/custom/templates/repo/pulls/edit.tmpl
@@ -13,7 +13,7 @@
 
 				<div class="field">
 					<div class="tw-p-0">
-						<textarea id="edit_area" name="content" class="tw-hidden" data-id="repo-{{.Repository.Name}}-{{.ReadmeTreePath}}" data-attachment-upload-url="{{.RepoLink}}/editor-attachments">{{.FileContent}}</textarea>
+						<textarea id="edit_area" name="content" class="tw-hidden" data-id="repo-{{.Repository.Name}}-{{.ReadmeTreePath}}" {{if .IsAttachmentEnabled}}data-attachment-upload-url="{{.RepoLink}}/editor-attachments"{{end}}>{{.FileContent}}</textarea>
 						<div class="editor-loading is-loading"></div>
 						<div id="toast-editor-container" style="min-height: 500px;"></div>
 					</div>

--- a/custom/templates/repo/pulls/edit.tmpl
+++ b/custom/templates/repo/pulls/edit.tmpl
@@ -13,7 +13,7 @@
 
 				<div class="field">
 					<div class="tw-p-0">
-						<textarea id="edit_area" name="content" class="tw-hidden" data-id="repo-{{.Repository.Name}}-{{.ReadmeTreePath}}" {{if .IsAttachmentEnabled}}data-attachment-upload-url="{{.RepoLink}}/editor-attachments"{{end}}>{{.FileContent}}</textarea>
+						<textarea id="edit_area" name="content" class="tw-hidden" data-id="repo-{{.Repository.Name}}-{{.ReadmeTreePath}}" data-raw-file-url="{{.RepoOperationsLink}}/raw/branch/{{PathEscapeSegments .BranchName}}/{{PathEscapeSegments .ReadmeTreePath}}" {{if .IsAttachmentEnabled}}data-attachment-upload-url="{{.RepoLink}}/editor-attachments"{{end}}>{{.FileContent}}</textarea>
 						<div class="editor-loading is-loading"></div>
 						<div id="toast-editor-container" style="min-height: 500px;"></div>
 					</div>

--- a/custom/templates/shared/repo/edit.tmpl
+++ b/custom/templates/shared/repo/edit.tmpl
@@ -83,7 +83,7 @@
 
              <div class="field">
                  <div class="tw-p-0">
-                     <textarea id="edit_area" name="content" class="tw-hidden" data-id="repo-{{.Repository.Name}}-{{.ReadmeTreePath}}" data-raw-file-url="{{.RepoLink}}/raw/branch/{{PathEscapeSegments .BranchName}}/{{PathEscapeSegments .ReadmeTreePath}}">{{.FileContent}}</textarea>
+                     <textarea id="edit_area" name="content" class="tw-hidden" data-id="repo-{{.Repository.Name}}-{{.ReadmeTreePath}}" data-raw-file-url="{{.RepoLink}}/raw/branch/{{PathEscapeSegments .BranchName}}/{{PathEscapeSegments .ReadmeTreePath}}" data-attachment-upload-url="{{.RepoLink}}/editor-attachments">{{.FileContent}}</textarea>
                      <div class="editor-loading is-loading"></div>
                      <div id="toast-editor-container" style="min-height: 500px;"></div>
                  </div>

--- a/custom/templates/shared/repo/edit.tmpl
+++ b/custom/templates/shared/repo/edit.tmpl
@@ -83,7 +83,7 @@
 
              <div class="field">
                  <div class="tw-p-0">
-                     <textarea id="edit_area" name="content" class="tw-hidden" data-id="repo-{{.Repository.Name}}-{{.ReadmeTreePath}}" data-raw-file-url="{{.RepoLink}}/raw/branch/{{PathEscapeSegments .BranchName}}/{{PathEscapeSegments .ReadmeTreePath}}" {{if .IsAttachmentEnabled}}data-attachment-upload-url="{{.RepoLink}}/editor-attachments"{{end}}>{{.FileContent}}</textarea>
+                     <textarea id="edit_area" name="content" class="tw-hidden" data-id="repo-{{.Repository.Name}}-{{.ReadmeTreePath}}" data-raw-file-url="{{.RepoOperationsLink}}/raw/branch/{{PathEscapeSegments .BranchName}}/{{PathEscapeSegments .ReadmeTreePath}}" {{if .IsAttachmentEnabled}}data-attachment-upload-url="{{.RepoLink}}/editor-attachments"{{end}}>{{.FileContent}}</textarea>
                      <div class="editor-loading is-loading"></div>
                      <div id="toast-editor-container" style="min-height: 500px;"></div>
                  </div>

--- a/custom/templates/shared/repo/edit.tmpl
+++ b/custom/templates/shared/repo/edit.tmpl
@@ -83,7 +83,7 @@
 
              <div class="field">
                  <div class="tw-p-0">
-                     <textarea id="edit_area" name="content" class="tw-hidden" data-id="repo-{{.Repository.Name}}-{{.ReadmeTreePath}}" data-raw-file-url="{{.RepoLink}}/raw/branch/{{PathEscapeSegments .BranchName}}/{{PathEscapeSegments .ReadmeTreePath}}" data-attachment-upload-url="{{.RepoLink}}/editor-attachments">{{.FileContent}}</textarea>
+                     <textarea id="edit_area" name="content" class="tw-hidden" data-id="repo-{{.Repository.Name}}-{{.ReadmeTreePath}}" data-raw-file-url="{{.RepoLink}}/raw/branch/{{PathEscapeSegments .BranchName}}/{{PathEscapeSegments .ReadmeTreePath}}" {{if .IsAttachmentEnabled}}data-attachment-upload-url="{{.RepoLink}}/editor-attachments"{{end}}>{{.FileContent}}</textarea>
                      <div class="editor-loading is-loading"></div>
                      <div id="toast-editor-container" style="min-height: 500px;"></div>
                  </div>

--- a/options/locale/locale_en-US.ini
+++ b/options/locale/locale_en-US.ini
@@ -1349,6 +1349,7 @@ editor.cannot_edit_too_large_file = The file is too large to be edited.
 editor.file_too_large_to_write = The file size exceeds the limit of %d MB and cannot be saved.
 editor.file_too_large = File "%s" exceeds the limit of %d MB and cannot be saved.
 editor.image_read_failed = Failed to read the image file.
+editor.image_upload_failed = Failed to upload the image file.
 editor.cannot_edit_non_text_files = Binary files cannot be edited in the web interface.
 editor.file_not_editable_hint = But you can still rename or move it.
 editor.edit_this_file = Edit File

--- a/routers/web/explore/repo.go
+++ b/routers/web/explore/repo.go
@@ -726,6 +726,7 @@ func prepareArticleView(ctx *context.Context, gitRepo *git.Repository, entries [
 			}
 		}
 		ctx.Data["FileSize"] = fileSize
+		ctx.Data["IsAttachmentEnabled"] = setting.Attachment.Enabled
 
 		// Set up fork-on-edit context data
 		prepareArticleForkOnEditData(ctx)

--- a/routers/web/repo/attachment.go
+++ b/routers/web/repo/attachment.go
@@ -79,6 +79,7 @@ func uploadAttachment(ctx *context.Context, repoID int64, allowedTypes string) {
 	log.Trace("New attachment uploaded: %s", attach.UUID)
 	ctx.JSON(http.StatusOK, map[string]string{
 		"uuid": attach.UUID,
+		"url":  setting.AppSubURL + "/attachments/" + attach.UUID,
 	})
 }
 

--- a/routers/web/repo/attachment.go
+++ b/routers/web/repo/attachment.go
@@ -104,10 +104,14 @@ func DeleteAttachment(ctx *context.Context) {
 	})
 }
 
-// editorAttachmentReadable reports whether an attachment that is not linked to an issue or
-// release (e.g. one uploaded via the file/article editor, carrying only a RepoID) may be
-// served to the current user based on their read permission for the owning repository.
-func editorAttachmentReadable(ctx *context.Context, attach *repo_model.Attachment) bool {
+// unlinkedAttachmentRepoReadable reports whether an attachment that is not linked to an issue
+// or release (carrying only a RepoID) may be served to the current user based on their read
+// permission for the owning repository. This covers file/article editor uploads (the intended
+// case), but also any other repo-scoped unlinked attachment such as a pending issue/release
+// draft. Because the originating unit can no longer be recovered without the link, it gates on
+// unit.TypeCode as a deliberately conservative default; the uploader-only fallback in
+// ServeAttachment still applies when this returns false.
+func unlinkedAttachmentRepoReadable(ctx *context.Context, attach *repo_model.Attachment) bool {
 	if attach.RepoID == 0 {
 		return false
 	}
@@ -144,7 +148,7 @@ func ServeAttachment(ctx *context.Context, uuid string) {
 		// Editor/article attachments carry only a RepoID (no issue/release). Authorize them by
 		// repository read permission so article readers can view embedded images; otherwise fall
 		// back to uploader-only for genuinely context-less uploads (e.g. pending comment drafts).
-		if !editorAttachmentReadable(ctx, attach) && !(ctx.IsSigned && attach.UploaderID == ctx.Doer.ID) {
+		if !unlinkedAttachmentRepoReadable(ctx, attach) && !(ctx.IsSigned && attach.UploaderID == ctx.Doer.ID) {
 			ctx.HTTPError(http.StatusNotFound)
 			return
 		}

--- a/routers/web/repo/attachment.go
+++ b/routers/web/repo/attachment.go
@@ -9,6 +9,7 @@ import (
 
 	access_model "code.gitea.io/gitea/models/perm/access"
 	repo_model "code.gitea.io/gitea/models/repo"
+	"code.gitea.io/gitea/models/unit"
 	"code.gitea.io/gitea/modules/httpcache"
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/setting"
@@ -29,6 +30,14 @@ func UploadIssueAttachment(ctx *context.Context) {
 // UploadReleaseAttachment response for uploading release attachments
 func UploadReleaseAttachment(ctx *context.Context) {
 	uploadAttachment(ctx, ctx.Repo.Repository.ID, setting.Repository.Release.AllowedTypes)
+}
+
+// UploadEditorAttachment uploads an attachment for the file/article editor. Unlike issue or
+// release attachments, these are never linked to an issue/release: they are referenced only
+// from the committed Markdown by RepoID. ServeAttachment authorizes such attachments by
+// repository read permission so embedded article images are visible to readers.
+func UploadEditorAttachment(ctx *context.Context) {
+	uploadAttachment(ctx, ctx.Repo.Repository.ID, setting.Attachment.AllowedTypes)
 }
 
 // UploadAttachment response for uploading attachments
@@ -95,6 +104,24 @@ func DeleteAttachment(ctx *context.Context) {
 	})
 }
 
+// editorAttachmentReadable reports whether an attachment that is not linked to an issue or
+// release (e.g. one uploaded via the file/article editor, carrying only a RepoID) may be
+// served to the current user based on their read permission for the owning repository.
+func editorAttachmentReadable(ctx *context.Context, attach *repo_model.Attachment) bool {
+	if attach.RepoID == 0 {
+		return false
+	}
+	repo, err := repo_model.GetRepositoryByID(ctx, attach.RepoID)
+	if err != nil || repo == nil {
+		return false
+	}
+	perm, err := access_model.GetUserRepoPermission(ctx, repo, ctx.Doer)
+	if err != nil {
+		return false
+	}
+	return perm.CanRead(unit.TypeCode)
+}
+
 // GetAttachment serve attachments with the given UUID
 func ServeAttachment(ctx *context.Context, uuid string) {
 	attach, err := repo_model.GetAttachmentByUUID(ctx, uuid)
@@ -113,8 +140,11 @@ func ServeAttachment(ctx *context.Context, uuid string) {
 		return
 	}
 
-	if repository == nil { // If not linked
-		if !(ctx.IsSigned && attach.UploaderID == ctx.Doer.ID) { // We block if not the uploader
+	if repository == nil { // If not linked to an issue or release
+		// Editor/article attachments carry only a RepoID (no issue/release). Authorize them by
+		// repository read permission so article readers can view embedded images; otherwise fall
+		// back to uploader-only for genuinely context-less uploads (e.g. pending comment drafts).
+		if !editorAttachmentReadable(ctx, attach) && !(ctx.IsSigned && attach.UploaderID == ctx.Doer.ID) {
 			ctx.HTTPError(http.StatusNotFound)
 			return
 		}

--- a/routers/web/repo/attachment.go
+++ b/routers/web/repo/attachment.go
@@ -32,14 +32,6 @@ func UploadReleaseAttachment(ctx *context.Context) {
 	uploadAttachment(ctx, ctx.Repo.Repository.ID, setting.Repository.Release.AllowedTypes)
 }
 
-// UploadEditorAttachment uploads an attachment for the file/article editor. Unlike issue or
-// release attachments, these are never linked to an issue/release: they are referenced only
-// from the committed Markdown by RepoID. ServeAttachment authorizes such attachments by
-// repository read permission so embedded article images are visible to readers.
-func UploadEditorAttachment(ctx *context.Context) {
-	uploadAttachment(ctx, ctx.Repo.Repository.ID, setting.Attachment.AllowedTypes)
-}
-
 // UploadAttachment response for uploading attachments
 func uploadAttachment(ctx *context.Context, repoID int64, allowedTypes string) {
 	if !setting.Attachment.Enabled {

--- a/routers/web/repo/attachment.go
+++ b/routers/web/repo/attachment.go
@@ -11,6 +11,7 @@ import (
 	repo_model "code.gitea.io/gitea/models/repo"
 	"code.gitea.io/gitea/models/unit"
 	"code.gitea.io/gitea/modules/httpcache"
+	"code.gitea.io/gitea/modules/httplib"
 	"code.gitea.io/gitea/modules/log"
 	"code.gitea.io/gitea/modules/setting"
 	"code.gitea.io/gitea/modules/storage"
@@ -71,7 +72,12 @@ func uploadAttachment(ctx *context.Context, repoID int64, allowedTypes string) {
 	log.Trace("New attachment uploaded: %s", attach.UUID)
 	ctx.JSON(http.StatusOK, map[string]string{
 		"uuid": attach.UUID,
-		"url":  setting.AppSubURL + "/attachments/" + attach.UUID,
+		// Absolute (scheme+host), not app-relative: markdown's link resolver treats a
+		// root-relative "/attachments/{uuid}" as relative to the current file's ref/path
+		// base and mangles it into "/{owner}/{repo}/media/branch/{ref}/attachments/{uuid}"
+		// (a 404) once the file is committed and rendered. A full URL is recognized as
+		// already-absolute and passed through untouched.
+		"url": httplib.MakeAbsoluteURL(ctx, "/attachments/"+attach.UUID),
 	})
 }
 

--- a/routers/web/repo/editor.go
+++ b/routers/web/repo/editor.go
@@ -357,6 +357,7 @@ func EditFile(ctx *context.Context) {
 	}
 
 	ctx.Data["EditorconfigJson"] = getContextRepoEditorConfig(ctx, ctx.Repo.TreePath)
+	ctx.Data["IsAttachmentEnabled"] = setting.Attachment.Enabled
 	ctx.HTML(http.StatusOK, tplEditFile)
 }
 

--- a/routers/web/repo/pull.go
+++ b/routers/web/repo/pull.go
@@ -789,6 +789,7 @@ func ViewPullEdit(ctx *context.Context) {
 	ctx.Data["ReadmeTreePath"] = readmeTreePath
 	ctx.Data["LastCommitID"] = headCommitID
 	ctx.Data["RepoOperationsLink"] = pull.HeadRepo.OperationsLink()
+	ctx.Data["IsAttachmentEnabled"] = setting.Attachment.Enabled
 
 	ctx.Data["IsIssuePoster"] = true
 	ctx.Data["HasIssuesOrPullsWritePermission"] = ctx.Repo.CanWriteIssuesOrPulls(issue.IsPull)

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -266,6 +266,10 @@ func registerRepoFileEditorRoutes(m *web.Router, reqRepoCodeWriter func(*context
 		// (referenced by /attachments/{uuid}) instead of inline base64. Only "code reader"
 		// is required so the "fork and edit" flow can upload before the fork is created;
 		// the enclosing groups already enforce sign-in and repo read access.
+		// Trade-off: like pending issue attachments, an upload that is never followed by a
+		// commit becomes a permanent orphan (no issue/release to link it to for cleanup), and
+		// any signed-in reader can create one. This is the same orphan class as issue drafts
+		// and is accepted here to keep fork-and-edit working without pre-creating the fork.
 		m.Post("/editor-attachments", repo.UploadEditorAttachment)
 	}, repo.MustBeEditable, context.RepoMustNotBeArchived())
 }

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -262,6 +262,11 @@ func registerRepoFileEditorRoutes(m *web.Router, reqRepoCodeWriter func(*context
 			m.Post("/upload-file", repo.UploadFileToServer)
 			m.Post("/upload-remove", repo.RemoveUploadFileFromServer)
 		}, repo.MustBeAbleToUpload, reqRepoCodeWriter)
+		// Stores images pasted/dropped in the article/file editor as repo attachments
+		// (referenced by /attachments/{uuid}) instead of inline base64. Only "code reader"
+		// is required so the "fork and edit" flow can upload before the fork is created;
+		// the enclosing groups already enforce sign-in and repo read access.
+		m.Post("/editor-attachments", repo.UploadEditorAttachment)
 	}, repo.MustBeEditable, context.RepoMustNotBeArchived())
 }
 

--- a/routers/web/web.go
+++ b/routers/web/web.go
@@ -263,14 +263,18 @@ func registerRepoFileEditorRoutes(m *web.Router, reqRepoCodeWriter func(*context
 			m.Post("/upload-remove", repo.RemoveUploadFileFromServer)
 		}, repo.MustBeAbleToUpload, reqRepoCodeWriter)
 		// Stores images pasted/dropped in the article/file editor as repo attachments
-		// (referenced by /attachments/{uuid}) instead of inline base64. Only "code reader"
-		// is required so the "fork and edit" flow can upload before the fork is created;
-		// the enclosing groups already enforce sign-in and repo read access.
+		// (referenced by /attachments/{uuid}) instead of inline base64. Reuses
+		// UploadIssueAttachment: the resulting attachment is never linked to an issue/release,
+		// only referenced from the committed Markdown by RepoID, and ServeAttachment
+		// authorizes such attachments by repository read permission so embedded article
+		// images are visible to readers. Only "code reader" is required so the "fork and
+		// edit" flow can upload before the fork is created; the enclosing groups already
+		// enforce sign-in and repo read access.
 		// Trade-off: like pending issue attachments, an upload that is never followed by a
 		// commit becomes a permanent orphan (no issue/release to link it to for cleanup), and
 		// any signed-in reader can create one. This is the same orphan class as issue drafts
 		// and is accepted here to keep fork-and-edit working without pre-creating the fork.
-		m.Post("/editor-attachments", repo.UploadEditorAttachment)
+		m.Post("/editor-attachments", repo.UploadIssueAttachment)
 	}, repo.MustBeEditable, context.RepoMustNotBeArchived())
 }
 

--- a/templates/base/head_script.tmpl
+++ b/templates/base/head_script.tmpl
@@ -44,6 +44,7 @@ If you introduce mistakes in it, Gitea JavaScript code wouldn't run correctly.
 			more_items: {{ctx.Locale.Tr "more_items"}},
 			editor_file_too_large: {{ctx.Locale.Tr "repo.editor.file_too_large"}},
 			editor_image_read_failed: {{ctx.Locale.Tr "repo.editor.image_read_failed"}},
+			editor_image_upload_failed: {{ctx.Locale.Tr "repo.editor.image_upload_failed"}},
 		},
 	};
 	{{/* in case some pages don't render the pageData, we make sure it is an object to prevent null access */}}

--- a/templates/repo/editor/edit.tmpl
+++ b/templates/repo/editor/edit.tmpl
@@ -28,7 +28,7 @@
 							<textarea id="edit_area" name="content" class="tw-hidden" data-id="repo-{{.Repository.Name}}-{{.TreePath}}"
 								data-previewable-extensions="{{.PreviewableExtensions}}"
 								data-line-wrap-extensions="{{.LineWrapExtensions}}"
-								data-attachment-upload-url="{{.RepoLink}}/editor-attachments"
+								{{if .IsAttachmentEnabled}}data-attachment-upload-url="{{.RepoLink}}/editor-attachments"{{end}}
 								data-raw-file-url="{{.RepoLink}}/raw/{{.RefTypeNameSubURL}}/{{.TreePath | PathEscapeSegments}}">{{.FileContent}}</textarea>
 							<div class="editor-loading is-loading"></div>
 						</div>

--- a/templates/repo/editor/edit.tmpl
+++ b/templates/repo/editor/edit.tmpl
@@ -28,6 +28,7 @@
 							<textarea id="edit_area" name="content" class="tw-hidden" data-id="repo-{{.Repository.Name}}-{{.TreePath}}"
 								data-previewable-extensions="{{.PreviewableExtensions}}"
 								data-line-wrap-extensions="{{.LineWrapExtensions}}"
+								data-attachment-upload-url="{{.RepoLink}}/editor-attachments"
 								data-raw-file-url="{{.RepoLink}}/raw/{{.RefTypeNameSubURL}}/{{.TreePath | PathEscapeSegments}}">{{.FileContent}}</textarea>
 							<div class="editor-loading is-loading"></div>
 						</div>

--- a/tests/integration/attachment_test.go
+++ b/tests/integration/attachment_test.go
@@ -29,7 +29,7 @@ func generateImg() bytes.Buffer {
 	return buff
 }
 
-func createAttachment(t *testing.T, session *TestSession, csrf, repoURL, filename string, buff bytes.Buffer, expectedStatus int) string {
+func uploadAttachmentTo(t *testing.T, session *TestSession, csrf, url, filename string, buff bytes.Buffer, expectedStatus int) string {
 	body := &bytes.Buffer{}
 
 	// Setup multi-part
@@ -41,7 +41,7 @@ func createAttachment(t *testing.T, session *TestSession, csrf, repoURL, filenam
 	err = writer.Close()
 	assert.NoError(t, err)
 
-	req := NewRequestWithBody(t, "POST", repoURL+"/issues/attachments", body)
+	req := NewRequestWithBody(t, "POST", url, body)
 	req.Header.Add("X-Csrf-Token", csrf)
 	req.Header.Add("Content-Type", writer.FormDataContentType())
 	resp := session.MakeRequest(t, req, expectedStatus)
@@ -54,27 +54,12 @@ func createAttachment(t *testing.T, session *TestSession, csrf, repoURL, filenam
 	return obj["uuid"]
 }
 
+func createAttachment(t *testing.T, session *TestSession, csrf, repoURL, filename string, buff bytes.Buffer, expectedStatus int) string {
+	return uploadAttachmentTo(t, session, csrf, repoURL+"/issues/attachments", filename, buff, expectedStatus)
+}
+
 func createEditorAttachment(t *testing.T, session *TestSession, csrf, repoURL, filename string, buff bytes.Buffer, expectedStatus int) string {
-	body := &bytes.Buffer{}
-	writer := multipart.NewWriter(body)
-	part, err := writer.CreateFormFile("file", filename)
-	assert.NoError(t, err)
-	_, err = io.Copy(part, &buff)
-	assert.NoError(t, err)
-	err = writer.Close()
-	assert.NoError(t, err)
-
-	req := NewRequestWithBody(t, "POST", repoURL+"/editor-attachments", body)
-	req.Header.Add("X-Csrf-Token", csrf)
-	req.Header.Add("Content-Type", writer.FormDataContentType())
-	resp := session.MakeRequest(t, req, expectedStatus)
-
-	if expectedStatus != http.StatusOK {
-		return ""
-	}
-	var obj map[string]string
-	DecodeJSON(t, resp, &obj)
-	return obj["uuid"]
+	return uploadAttachmentTo(t, session, csrf, repoURL+"/editor-attachments", filename, buff, expectedStatus)
 }
 
 // TestEditorAttachmentServedToRepoReaders verifies that an attachment uploaded via the

--- a/tests/integration/attachment_test.go
+++ b/tests/integration/attachment_test.go
@@ -54,6 +54,57 @@ func createAttachment(t *testing.T, session *TestSession, csrf, repoURL, filenam
 	return obj["uuid"]
 }
 
+func createEditorAttachment(t *testing.T, session *TestSession, csrf, repoURL, filename string, buff bytes.Buffer, expectedStatus int) string {
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	part, err := writer.CreateFormFile("file", filename)
+	assert.NoError(t, err)
+	_, err = io.Copy(part, &buff)
+	assert.NoError(t, err)
+	err = writer.Close()
+	assert.NoError(t, err)
+
+	req := NewRequestWithBody(t, "POST", repoURL+"/editor-attachments", body)
+	req.Header.Add("X-Csrf-Token", csrf)
+	req.Header.Add("Content-Type", writer.FormDataContentType())
+	resp := session.MakeRequest(t, req, expectedStatus)
+
+	if expectedStatus != http.StatusOK {
+		return ""
+	}
+	var obj map[string]string
+	DecodeJSON(t, resp, &obj)
+	return obj["uuid"]
+}
+
+// TestEditorAttachmentServedToRepoReaders verifies that an attachment uploaded via the
+// article/file editor (linked only by RepoID, never to an issue/release) is served to anyone
+// with repo read permission — not just the uploader — so embedded article images are visible
+// to readers, while remaining hidden from users without read access to a private repo.
+func TestEditorAttachmentServedToRepoReaders(t *testing.T) {
+	defer tests.PrepareTestEnv(t)()
+
+	owner := loginUser(t, "user2")
+	user8 := loginUser(t, "user8")
+
+	// A fresh request per call: session.MakeRequest stamps the session cookie onto the
+	// request, so reusing one *http.Request across sessions would leak the first cookie.
+	attachReq := func(uuid string) *RequestWrapper { return NewRequest(t, "GET", "/attachments/"+uuid) }
+
+	// Public repo: readable by the uploader and by any other reader (incl. anonymous). Serving
+	// to non-uploaders is the new behavior — previously an unlinked attachment was uploader-only.
+	pubUUID := createEditorAttachment(t, owner, GetUserCSRFToken(t, owner), "user2/repo1", "image.png", generateImg(), http.StatusOK)
+	owner.MakeRequest(t, attachReq(pubUUID), http.StatusOK)
+	user8.MakeRequest(t, attachReq(pubUUID), http.StatusOK)
+	MakeRequest(t, attachReq(pubUUID), http.StatusOK) // anonymous
+
+	// Private repo: readable by the owner, blocked for users without read access.
+	privUUID := createEditorAttachment(t, owner, GetUserCSRFToken(t, owner), "user2/repo2", "image.png", generateImg(), http.StatusOK)
+	owner.MakeRequest(t, attachReq(privUUID), http.StatusOK)
+	user8.MakeRequest(t, attachReq(privUUID), http.StatusNotFound)
+	MakeRequest(t, attachReq(privUUID), http.StatusNotFound) // anonymous
+}
+
 func TestCreateAnonymousAttachment(t *testing.T) {
 	defer tests.PrepareTestEnv(t)()
 	session := emptyTestSession(t)

--- a/web_src/js/features/toast-editor.ts
+++ b/web_src/js/features/toast-editor.ts
@@ -111,7 +111,7 @@ export async function createToastEditor(
             const resp = await POST(attachmentUploadUrl, {data: form});
             if (!resp.ok) throw new Error(`attachment upload failed: ${resp.status}`);
             const data = await resp.json();
-            callback(`/attachments/${data.uuid}`, name);
+            callback(data.url, name);
           } catch (err) {
             console.error(err);
             showErrorToast(window.config.i18n.editor_image_upload_failed || 'Failed to upload the image file.');

--- a/web_src/js/features/toast-editor.ts
+++ b/web_src/js/features/toast-editor.ts
@@ -4,6 +4,7 @@ import '@toast-ui/editor/dist/toastui-editor.css';
 import {createBase64WidgetRule, installBase64WidgetPatch} from './comp/base64ImageWidget.ts';
 import {showErrorToast} from '../modules/toast.ts';
 import {ensureFilesWithinLimit, getMaxAttachmentSize, showFileTooLargeError} from './comp/editorFileLimit.ts';
+import {POST} from '../modules/fetch.ts';
 
 export type ToastEditorOptions = {
   height?: string;
@@ -61,6 +62,8 @@ export async function createToastEditor(
 
   // Server-provided raw URL of the file being edited, used to resolve relative image paths.
   const rawFileUrl = textarea.getAttribute('data-raw-file-url') || '';
+  // Endpoint that stores a pasted/dropped image as a repo attachment and returns its uuid.
+  const attachmentUploadUrl = textarea.getAttribute('data-attachment-upload-url') || '';
 
   // Initialize Toast UI Editor
   // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents -- Editor type has issues
@@ -84,15 +87,34 @@ export async function createToastEditor(
       },
     },
     hooks: {
-      addImageBlobHook: (blob: Blob, callback: (url: string, text?: string) => void) => {
+      addImageBlobHook: async (blob: Blob, callback: (url: string, text?: string) => void) => {
         const max = getMaxAttachmentSize();
         if (max && blob.size > max) {
           showFileTooLargeError((blob as File).name || 'image');
           return;
         }
+        const name = (blob as File).name || 'image';
+        // Upload the image as a repo attachment and reference it by URL. Storing it inline as
+        // base64 bloats the Markdown and makes a single line exceed MAX_GIT_DIFF_LINE_CHARACTERS,
+        // which suppresses the whole file diff (issue #233).
+        if (attachmentUploadUrl) {
+          try {
+            const form = new FormData();
+            form.append('file', blob, name);
+            const resp = await POST(attachmentUploadUrl, {data: form});
+            if (!resp.ok) throw new Error(`attachment upload failed: ${resp.status}`);
+            const data = await resp.json();
+            callback(`/attachments/${data.uuid}`, name);
+          } catch (err) {
+            console.error(err);
+            showErrorToast(window.config.i18n.editor_image_read_failed || 'Failed to upload the image file.');
+          }
+          return;
+        }
+        // Fallback when no upload endpoint is configured: embed as base64 so the image is not lost.
         const reader = new FileReader();
         reader.addEventListener('load', () => {
-          callback(reader.result as string, (blob as File).name || 'image');
+          callback(reader.result as string, name);
         });
         reader.addEventListener('error', () => {
           showErrorToast(window.config.i18n.editor_image_read_failed || 'Failed to read the image file.');

--- a/web_src/js/features/toast-editor.ts
+++ b/web_src/js/features/toast-editor.ts
@@ -93,7 +93,14 @@ export async function createToastEditor(
           showFileTooLargeError((blob as File).name || 'image');
           return;
         }
-        const name = (blob as File).name || 'image';
+        let name = (blob as File).name || '';
+        if (!name.includes('.')) {
+          // Clipboard screenshots often arrive without a filename/extension. The server's
+          // attachment type check is extension-based, so derive one from the MIME type;
+          // otherwise the upload is rejected (e.g. "image/svg+xml" -> "svg").
+          const ext = (blob.type.split('/')[1] || 'png').split('+')[0];
+          name = name ? `${name}.${ext}` : `image.${ext}`;
+        }
         // Upload the image as a repo attachment and reference it by URL. Storing it inline as
         // base64 bloats the Markdown and makes a single line exceed MAX_GIT_DIFF_LINE_CHARACTERS,
         // which suppresses the whole file diff (issue #233).
@@ -107,7 +114,7 @@ export async function createToastEditor(
             callback(`/attachments/${data.uuid}`, name);
           } catch (err) {
             console.error(err);
-            showErrorToast(window.config.i18n.editor_image_read_failed || 'Failed to upload the image file.');
+            showErrorToast(window.config.i18n.editor_image_upload_failed || 'Failed to upload the image file.');
           }
           return;
         }

--- a/web_src/js/features/toast-editor.ts
+++ b/web_src/js/features/toast-editor.ts
@@ -94,7 +94,9 @@ export async function createToastEditor(
           return;
         }
         let name = (blob as File).name || '';
-        if (!name.includes('.')) {
+        const dot = name.lastIndexOf('.');
+        const hasExtension = dot > 0 && dot < name.length - 1;
+        if (!hasExtension) {
           // Clipboard screenshots often arrive without a filename/extension. The server's
           // attachment type check is extension-based, so derive one from the MIME type;
           // otherwise the upload is rejected (e.g. "image/svg+xml" -> "svg").


### PR DESCRIPTION
Closes #233: store editor images as repo attachments instead of inline base64

Problem

Adding a YouTube (or other media) link to an article triggered "File diff suppressed because one or more lines are too long", even though no visible line exceeded MAX_GIT_DIFF_LINE_CHARACTERS.

Root cause was two-layered:
1. Where the base64 came from — the Toast UI article editor's addImageBlobHook converted every inserted image blob (including thumbnails pulled in from pasted rich HTML) to a base64 data: URI and stored it directly in the Markdown.
2. Why it broke the diff — a single base64 line is enormous, so parseHunks flagged the file with IsIncompleteLineTooLong and the whole file diff was hidden.

PR #237 patched the symptoms (strip external images on paste; substitute a placeholder in the diff). This change fixes the source: articles no longer contain base64 at all.

Approach & key decisions

- Base64 is the wrong storage. The goal is only: see the image while editing, keep the Markdown source clean/readable, round-trip on re-edit. Real files referenced by URL satisfy all three; base64 satisfies none well.
- Reuse the existing attachment pipeline. Forkana's comment editor already uploads images to /attachments/<uuid> and references them by URL. We make the article editor do the same.
- Permission-model discovery. Attachments are normally served only if linked to an issue/release (ServeAttachment → LinkedRepository); an unlinked attachment is served only to its uploader. An article is a git file and never links to anything, so article images would 404 for every other reader. This required a deliberate serve-permission change (Option 1, approved): authorize issue/release-unlinked attachments by repo read permission.
- Accepted trade-off: this also makes pending (unsubmitted) attachments across the app readable by anyone with repo read access who has the random UUID. On a public repo that's effectively "readable if you have the link." Acceptable given UUIDs are unguessable and the content was intended to be published.

Solution

- web_src/js/features/toast-editor.ts: addImageBlobHook uploads the blob to the editor attachment endpoint and inserts ![alt](/attachments/<uuid>); base64 kept only as a fallback when no upload URL is present
- custom/templates/repo/editor/edit.tmpl: Adds data-attachment-upload-url to the editor textarea — this is the template that actually renders
-  templates/repo/editor/edit.tmpl: Same attribute on the base template, for upstream parity
- routers/web/web.go: New POST /editor-attachments route inside the shared editor route group (inherits sign-in + code-reader, so the fork-and-edit flow can upload before forking)
- routers/web/repo/attachment.go: UploadEditorAttachment handler; ServeAttachment now authorizes issue/release-unlinked attachments via repo read permission (editorAttachmentReadable)
-  tests/integration/attachment_test.go: TestEditorAttachmentServedToRepoReaders — public-repo image readable by uploader/other users/anonymous; private-repo image 404 for non-members

Pre-existing articles that already contain base64 still render (the base64 widget is untouched).

Co Author Opus 4.8