### PR TITLE
Fix #262: introduce lossless markdown tracking to prevent unwanted se…

### DIFF
--- a/web_src/js/features/comp/ToastCommentEditor.ts
+++ b/web_src/js/features/comp/ToastCommentEditor.ts
@@ -21,6 +21,7 @@ import {
   initDropzone,
 } from '../dropzone.ts';
 import {createBase64WidgetRule, installBase64WidgetPatch} from './base64ImageWidget.ts';
+import {installLosslessMarkdownTracker} from './losslessMarkdown.ts';
 import {ensureFilesWithinLimit} from './editorFileLimit.ts';
 
 // Event dispatched when editor content changes
@@ -102,16 +103,6 @@ export class ToastCommentEditor {
       usageStatistics: false,
       hideModeSwitch: false,
       toolbarItems,
-      events: {
-        change: () => {
-          if (this.editor) {
-            const content = this.editor.getMarkdown();
-            this.textarea.value = content;
-            this.textarea.dispatchEvent(new Event('change'));
-            triggerEditorContentChanged(this.container);
-          }
-        },
-      },
       widgetRules: [
         createBase64WidgetRule(() => this.editor),
       ],
@@ -119,10 +110,12 @@ export class ToastCommentEditor {
 
     // Override getMarkdown to strip internal $$widget placeholders
     installBase64WidgetPatch(this.editor);
-    // Set initial content from textarea
-    if (this.textarea.value) {
-      this.editor.setMarkdown(this.textarea.value);
-    }
+    // Keep the user's markdown source byte-identical across mode switches unless they
+    // actually edit in the visual editor (issue #262). Installs itself on top of the widget
+    // patch, loads the initial content, and overrides getMarkdown/setMarkdown so every
+    // existing call site below (and value()) stays lossless with no further changes.
+    this.textarea.addEventListener('change', () => triggerEditorContentChanged(this.container));
+    installLosslessMarkdownTracker(this.editor, this.textarea);
 
     // Rename mode switch labels
     const switchEl = this.editorWrapper.querySelector('.toastui-editor-mode-switch');

--- a/web_src/js/features/comp/base64ImageWidget.ts
+++ b/web_src/js/features/comp/base64ImageWidget.ts
@@ -104,10 +104,13 @@ export function createBase64WidgetRule(
   };
 }
 
+const WIDGET_PLACEHOLDER_RE = /\$\$widget\d+\s([\s\S]*?)\$\$/g;
+
+export function stripWidgetPlaceholders(content: string): string {
+  return content.replace(WIDGET_PLACEHOLDER_RE, '$1');
+}
+
 export function installBase64WidgetPatch(editor: Editor): void {
   const originalGetMarkdown = editor.getMarkdown.bind(editor);
-  editor.getMarkdown = () => {
-    const content = originalGetMarkdown();
-    return content.replace(/\$\$widget\d+\s([\s\S]*?)\$\$/g, '$1');
-  };
+  editor.getMarkdown = () => stripWidgetPlaceholders(originalGetMarkdown());
 }

--- a/web_src/js/features/comp/losslessMarkdown.test.ts
+++ b/web_src/js/features/comp/losslessMarkdown.test.ts
@@ -1,0 +1,188 @@
+import {installLosslessMarkdownTracker, type LosslessEditor} from './losslessMarkdown.ts';
+
+// Fake mirroring the verified Toast UI 3.2.2 behaviors the tracker depends on:
+// - WYSIWYG getMarkdown() serializes lossily (here: escapes `[` and `_`);
+// - markdown-mode getMarkdown() returns the raw text;
+// - changeMode sets the mode BEFORE converting, the conversion overwrites the markdown
+//   document with the lossy serialization and fires `change`, THEN `changeMode` is emitted.
+class FakeEditor implements LosslessEditor {
+  mode: 'markdown' | 'wysiwyg';
+  mdText = '';
+  wwSource = '';
+  private handlers: Record<string, Array<(...args: unknown[]) => void>> = {};
+
+  constructor(mode: 'markdown' | 'wysiwyg' = 'wysiwyg') {
+    this.mode = mode;
+  }
+
+  serialize(s: string): string {
+    return s.replaceAll('[', '\\[').replaceAll('_', '\\_');
+  }
+
+  on(event: string, handler: (...args: unknown[]) => void) {
+    (this.handlers[event] ??= []).push(handler);
+  }
+
+  private emit(event: string, ...args: unknown[]) {
+    for (const h of this.handlers[event] ?? []) h(...args);
+  }
+
+  isMarkdownMode() {
+    return this.mode === 'markdown';
+  }
+
+  getMarkdown() {
+    return this.isMarkdownMode() ? this.mdText : this.serialize(this.wwSource);
+  }
+
+  setMarkdown(markdown: string, _cursorToEnd?: boolean) {
+    this.mdText = markdown;
+    if (!this.isMarkdownMode()) this.wwSource = markdown;
+    this.emit('change');
+  }
+
+  changeMode(mode: 'markdown' | 'wysiwyg') {
+    if (this.mode === mode) return;
+    this.mode = mode; // the core sets the mode before converting
+    if (mode === 'wysiwyg') {
+      this.wwSource = this.mdText;
+    } else {
+      this.mdText = this.serialize(this.wwSource); // lossy overwrite of the md document
+    }
+    this.emit('change');
+    this.emit('changeMode', mode);
+  }
+
+  // user edits
+  typeMarkdown(text: string) {
+    this.mdText = text;
+    this.emit('change');
+  }
+
+  typeWysiwyg(text: string) {
+    this.wwSource = text;
+    this.emit('change');
+  }
+}
+
+const GNARLY = '# Title\n\n[Research program](./Research_program "Research program")\n\nsnake_case_words and *literal* chars';
+
+function setup(mode: 'markdown' | 'wysiwyg' = 'wysiwyg', initial = GNARLY) {
+  const fake = new FakeEditor(mode);
+  const textarea = document.createElement('textarea');
+  textarea.value = initial;
+  // editor as consumers see it: tracker overrides getMarkdown/setMarkdown on this object
+  const editor = fake as LosslessEditor & FakeEditor;
+  installLosslessMarkdownTracker(editor, textarea);
+  return {fake, textarea, editor};
+}
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+test('untouched document in WYSIWYG mode round-trips byte-identical', () => {
+  const {fake, textarea, editor} = setup();
+  expect(fake.serialize(fake.wwSource)).not.toBe(GNARLY); // sanity: the serializer IS lossy
+  expect(editor.getMarkdown()).toBe(GNARLY);
+  expect(textarea.value).toBe(GNARLY);
+});
+
+test('switching Visual→Source without edits restores the pristine source', async () => {
+  const {fake, textarea, editor} = setup();
+  fake.changeMode('markdown');
+  await flush();
+  expect(fake.mdText).toBe(GNARLY); // the editor document itself is restored
+  expect(editor.getMarkdown()).toBe(GNARLY);
+  expect(textarea.value).toBe(GNARLY);
+});
+
+test('mode thrashing without edits stays pristine', async () => {
+  const {fake, textarea, editor} = setup();
+  for (let i = 0; i < 3; i++) {
+    fake.changeMode('markdown');
+    await flush();
+    fake.changeMode('wysiwyg');
+  }
+  fake.changeMode('markdown');
+  await flush();
+  expect(editor.getMarkdown()).toBe(GNARLY);
+  expect(textarea.value).toBe(GNARLY);
+});
+
+test('edits made in Source mode are kept verbatim', async () => {
+  const {fake, textarea, editor} = setup();
+  fake.changeMode('markdown');
+  await flush();
+  const edited = `${GNARLY}\n\nappended line`;
+  fake.typeMarkdown(edited);
+  expect(editor.getMarkdown()).toBe(edited);
+  expect(textarea.value).toBe(edited);
+  // and they survive an untouched Visual round-trip
+  fake.changeMode('wysiwyg');
+  fake.changeMode('markdown');
+  await flush();
+  expect(editor.getMarkdown()).toBe(edited);
+  expect(fake.mdText).toBe(edited);
+});
+
+test('a genuine Visual edit adopts the serialized form', async () => {
+  const {fake, textarea, editor} = setup();
+  fake.typeWysiwyg('Hello [world]');
+  const serialized = fake.serialize('Hello [world]');
+  expect(editor.getMarkdown()).toBe(serialized);
+  expect(textarea.value).toBe(serialized);
+  fake.changeMode('markdown');
+  await flush();
+  expect(editor.getMarkdown()).toBe(serialized);
+  expect(fake.mdText).toBe(serialized);
+});
+
+test('a Visual edit that is fully undone still restores the pristine source', async () => {
+  const {fake, editor} = setup();
+  fake.typeWysiwyg('changed');
+  fake.typeWysiwyg(GNARLY); // back to the baseline content
+  fake.changeMode('markdown');
+  await flush();
+  expect(editor.getMarkdown()).toBe(GNARLY);
+  expect(fake.mdText).toBe(GNARLY);
+});
+
+test('external setMarkdown becomes the new pristine source (lossless in WYSIWYG mode)', () => {
+  const {textarea, editor} = setup();
+  editor.setMarkdown('New [text] with_underscores');
+  expect(editor.getMarkdown()).toBe('New [text] with_underscores');
+  expect(textarea.value).toBe('New [text] with_underscores');
+});
+
+test('markdown-only editing is verbatim from the start', () => {
+  const {fake, textarea, editor} = setup('markdown');
+  expect(editor.getMarkdown()).toBe(GNARLY);
+  fake.typeMarkdown('plain **edit**');
+  expect(editor.getMarkdown()).toBe('plain **edit**');
+  expect(textarea.value).toBe('plain **edit**');
+});
+
+test('installation does not rewrite the textarea at load time', () => {
+  const {textarea} = setup();
+  expect(textarea.value).toBe(GNARLY); // not the serialized form
+});
+
+test('empty initial content stays empty', () => {
+  const {textarea, editor} = setup('wysiwyg', '');
+  expect(editor.getMarkdown()).toBe('');
+  expect(textarea.value).toBe('');
+});
+
+test('comparisons run through the patched getMarkdown (widget stripping applied)', async () => {
+  const fake = new FakeEditor('wysiwyg');
+  // simulate installBase64WidgetPatch being installed first
+  const original = fake.getMarkdown.bind(fake);
+  fake.getMarkdown = () => original().replace(/\$\$widget\d+\s([\s\S]*?)\$\$/g, '$1');
+  const textarea = document.createElement('textarea');
+  textarea.value = GNARLY;
+  installLosslessMarkdownTracker(fake, textarea);
+  // WYSIWYG serialization containing a widget placeholder must not read as a user edit
+  fake.wwSource = GNARLY; // untouched
+  fake.changeMode('markdown');
+  await flush();
+  expect(fake.getMarkdown()).toBe(GNARLY);
+});

--- a/web_src/js/features/comp/losslessMarkdown.test.ts
+++ b/web_src/js/features/comp/losslessMarkdown.test.ts
@@ -1,4 +1,5 @@
 import {installLosslessMarkdownTracker, type LosslessEditor} from './losslessMarkdown.ts';
+import {stripWidgetPlaceholders} from './base64ImageWidget.ts';
 
 // Fake mirroring the verified Toast UI 3.2.2 behaviors the tracker depends on:
 // - WYSIWYG getMarkdown() serializes lossily (here: escapes `[` and `_`);
@@ -176,7 +177,7 @@ test('comparisons run through the patched getMarkdown (widget stripping applied)
   const fake = new FakeEditor('wysiwyg');
   // simulate installBase64WidgetPatch being installed first
   const original = fake.getMarkdown.bind(fake);
-  fake.getMarkdown = () => original().replace(/\$\$widget\d+\s([\s\S]*?)\$\$/g, '$1');
+  fake.getMarkdown = () => stripWidgetPlaceholders(original());
   const textarea = document.createElement('textarea');
   textarea.value = GNARLY;
   installLosslessMarkdownTracker(fake, textarea);

--- a/web_src/js/features/comp/losslessMarkdown.test.ts
+++ b/web_src/js/features/comp/losslessMarkdown.test.ts
@@ -119,6 +119,7 @@ test('edits made in Source mode are kept verbatim', async () => {
   expect(textarea.value).toBe(edited);
   // and they survive an untouched Visual round-trip
   fake.changeMode('wysiwyg');
+  await flush();
   fake.changeMode('markdown');
   await flush();
   expect(editor.getMarkdown()).toBe(edited);

--- a/web_src/js/features/comp/losslessMarkdown.ts
+++ b/web_src/js/features/comp/losslessMarkdown.ts
@@ -1,0 +1,120 @@
+// Lossless markdown tracking for Toast UI Editor (issue #262).
+//
+// Toast UI's WYSIWYG→markdown serializer normalizes and escapes the source (headers
+// rewritten, `\[` `\_` `\#` escapes added), and the core overwrites the markdown document
+// with that lossy serialization on every Visual→Source mode switch — even when the user
+// edited nothing. Committing `getMarkdown()` therefore rewrote articles wholesale and the
+// escaped output no longer rendered as markdown.
+//
+// This tracker keeps the authoritative source text alongside the editor and guarantees:
+//   - an untouched document round-trips byte-identical, regardless of tab switching;
+//   - edits made purely in Source (markdown) mode keep the rest of the text verbatim;
+//   - only a genuine edit in the Visual editor adopts the serialized form (unavoidable:
+//     Toast UI's serializer is not configurable, and the visual edit rewrote the doc anyway).
+//
+// It installs itself by overriding `editor.getMarkdown`/`editor.setMarkdown` (the same
+// pattern as installBase64WidgetPatch, which must be installed first so widget-placeholder
+// stripping is applied uniformly to every comparison).
+
+// Minimal structural surface of Toast UI Editor used by the tracker, so it can be
+// unit-tested against a fake editor (the real editor cannot run under happy-dom).
+export type LosslessEditor = {
+  isMarkdownMode(): boolean;
+  getMarkdown(): string;
+  setMarkdown(markdown: string, cursorToEnd?: boolean): void;
+  on(event: string, handler: (...args: unknown[]) => void): void;
+};
+
+export function installLosslessMarkdownTracker(editor: LosslessEditor, textarea: HTMLTextAreaElement): void {
+  // Captured after installBase64WidgetPatch: strips $$widget$$ placeholders, so baseline
+  // comparisons can never differ on placeholder syntax alone.
+  const baseGetMarkdown = editor.getMarkdown.bind(editor);
+  const baseSetMarkdown = editor.setMarkdown.bind(editor);
+
+  // Authoritative lossless markdown. In markdown mode the editor text is raw and kept in
+  // sync by the change handler; in WYSIWYG mode this holds the last lossless text.
+  let sourceText = textarea.value;
+  // Serialization snapshot taken on every entry into WYSIWYG mode (including initial
+  // load). Equality with the current serialization ⇔ "no effective Visual edit".
+  let wwBaseline = '';
+  // The pristine source at the moment WYSIWYG mode was entered; restored when the user
+  // returns to Source mode without having made an effective Visual edit.
+  let mdSnapshot = sourceText;
+  // Suppresses the change handler during programmatic setMarkdown (initial load, restore).
+  let suppressChange = false;
+
+  const getLosslessMarkdown = (): string => {
+    if (editor.isMarkdownMode()) return sourceText;
+    const serialized = baseGetMarkdown();
+    return serialized === wwBaseline ? sourceText : serialized;
+  };
+
+  const syncTextarea = () => {
+    textarea.value = getLosslessMarkdown();
+    textarea.dispatchEvent(new Event('change'));
+  };
+
+  // Programmatic content replacement: the given text becomes the new pristine source.
+  const applyMarkdown = (markdown: string, cursorToEnd?: boolean) => {
+    suppressChange = true;
+    try {
+      baseSetMarkdown(markdown, cursorToEnd);
+    } finally {
+      suppressChange = false;
+    }
+    sourceText = markdown;
+    mdSnapshot = markdown;
+    if (!editor.isMarkdownMode()) wwBaseline = baseGetMarkdown();
+    syncTextarea();
+  };
+
+  editor.on('change', () => {
+    if (suppressChange) return;
+    // Markdown mode is lossless (raw line texts), so the editor content is authoritative.
+    // WYSIWYG changes are only adopted lazily via getLosslessMarkdown's baseline check.
+    if (editor.isMarkdownMode()) sourceText = baseGetMarkdown();
+    syncTextarea();
+  });
+
+  editor.on('changeMode', (...args: unknown[]) => {
+    const mode = args[0] as string;
+    if (mode === 'wysiwyg') {
+      mdSnapshot = sourceText;
+      wwBaseline = baseGetMarkdown();
+      syncTextarea();
+      return;
+    }
+    // mode === 'markdown': the core just overwrote the markdown document with the WYSIWYG
+    // serialization (lossy) — even if nothing was edited — and that write already ran
+    // through the change handler above, clobbering sourceText.
+    const serialized = baseGetMarkdown();
+    if (serialized === wwBaseline) {
+      // No effective Visual edit: restore the pristine source. Deferred, because the core
+      // still restores focus/selection (with positions mapped against the serialized doc)
+      // after emitting `changeMode`; replacing the document synchronously would race that.
+      sourceText = mdSnapshot;
+      queueMicrotask(() => {
+        // The user may have switched modes again before the microtask ran.
+        if (!editor.isMarkdownMode()) return;
+        applyMarkdown(sourceText, false);
+      });
+    } else {
+      // Genuine Visual edits: the serialization is now the authoritative source.
+      sourceText = serialized;
+    }
+    syncTextarea();
+  });
+
+  // Initial content load, guarded so the setMarkdown-triggered change event cannot
+  // overwrite the textarea (and thus later submits) with WYSIWYG-normalized output.
+  if (textarea.value) {
+    applyMarkdown(textarea.value);
+  } else if (!editor.isMarkdownMode()) {
+    wwBaseline = baseGetMarkdown();
+  }
+
+  // Every consumer — submit handlers reading getMarkdown(), external code replacing the
+  // content via setMarkdown() — now goes through the lossless layer.
+  editor.getMarkdown = getLosslessMarkdown;
+  editor.setMarkdown = applyMarkdown;
+}

--- a/web_src/js/features/comp/losslessMarkdown.ts
+++ b/web_src/js/features/comp/losslessMarkdown.ts
@@ -80,8 +80,18 @@ export function installLosslessMarkdownTracker(editor: LosslessEditor, textarea:
     if (mode !== 'markdown' && mode !== 'wysiwyg') return;
     if (mode === 'wysiwyg') {
       mdSnapshot = sourceText;
-      wysiwygBaseline = baseGetMarkdown();
-      syncTextarea();
+      // Deferred for the same reason as the markdown-mode branch below: the core still
+      // reads its own tracked cursor/selection mapping and applies it to the WYSIWYG model
+      // *after* emitting `changeMode`. Calling baseGetMarkdown() synchronously here forces
+      // Toast UI's internal markdown<->WYSIWYG convertor to run a serialization pass right
+      // in the middle of that, which can leave it with stale position-mapping state; the
+      // core's own subsequent setSelection(pos) then throws a ProseMirror range error.
+      queueMicrotask(() => {
+        // The user may have switched modes again before the microtask ran.
+        if (editor.isMarkdownMode()) return;
+        wysiwygBaseline = baseGetMarkdown();
+        syncTextarea();
+      });
       return;
     }
     // mode === 'markdown': the core just overwrote the markdown document with the WYSIWYG

--- a/web_src/js/features/comp/losslessMarkdown.ts
+++ b/web_src/js/features/comp/losslessMarkdown.ts
@@ -92,11 +92,18 @@ export function installLosslessMarkdownTracker(editor: LosslessEditor, textarea:
       // No effective Visual edit: restore the pristine source. Deferred, because the core
       // still restores focus/selection (with positions mapped against the serialized doc)
       // after emitting `changeMode`; replacing the document synchronously would race that.
+      // Must pass cursorToEnd=true: with false, Toast UI's markdown editor does a wholesale
+      // ProseMirror document replace and lets the transaction auto-map the old (now-stale)
+      // selection through it. That mapped position is not just imprecise, it can point
+      // outside the new document's node structure entirely (different text, different
+      // length), and Toast UI's next mode switch reuses that broken position to restore the
+      // WYSIWYG selection, throwing "Index N out of range" from inside ProseMirror. Passing
+      // true makes it call moveCursorToEnd instead, which is always structurally valid.
       sourceText = mdSnapshot;
       queueMicrotask(() => {
         // The user may have switched modes again before the microtask ran.
         if (!editor.isMarkdownMode()) return;
-        applyMarkdown(sourceText, false);
+        applyMarkdown(sourceText, true);
       });
     } else {
       // Genuine Visual edits: the serialization is now the authoritative source.

--- a/web_src/js/features/comp/losslessMarkdown.ts
+++ b/web_src/js/features/comp/losslessMarkdown.ts
@@ -2,7 +2,7 @@
 //
 // Toast UI's WYSIWYG→markdown serializer normalizes and escapes the source (headers
 // rewritten, `\[` `\_` `\#` escapes added), and the core overwrites the markdown document
-// with that lossy serialization on every Visual→Source mode switch — even when the user
+// with that lossy serialization on every Visual→Source mode switch, even when the user
 // edited nothing. Committing `getMarkdown()` therefore rewrote articles wholesale and the
 // escaped output no longer rendered as markdown.
 //
@@ -36,7 +36,7 @@ export function installLosslessMarkdownTracker(editor: LosslessEditor, textarea:
   let sourceText = textarea.value;
   // Serialization snapshot taken on every entry into WYSIWYG mode (including initial
   // load). Equality with the current serialization ⇔ "no effective Visual edit".
-  let wwBaseline = '';
+  let wysiwygBaseline = '';
   // The pristine source at the moment WYSIWYG mode was entered; restored when the user
   // returns to Source mode without having made an effective Visual edit.
   let mdSnapshot = sourceText;
@@ -46,7 +46,7 @@ export function installLosslessMarkdownTracker(editor: LosslessEditor, textarea:
   const getLosslessMarkdown = (): string => {
     if (editor.isMarkdownMode()) return sourceText;
     const serialized = baseGetMarkdown();
-    return serialized === wwBaseline ? sourceText : serialized;
+    return serialized === wysiwygBaseline ? sourceText : serialized;
   };
 
   const syncTextarea = () => {
@@ -64,31 +64,31 @@ export function installLosslessMarkdownTracker(editor: LosslessEditor, textarea:
     }
     sourceText = markdown;
     mdSnapshot = markdown;
-    if (!editor.isMarkdownMode()) wwBaseline = baseGetMarkdown();
+    if (!editor.isMarkdownMode()) wysiwygBaseline = baseGetMarkdown();
     syncTextarea();
   };
 
   editor.on('change', () => {
     if (suppressChange) return;
-    // Markdown mode is lossless (raw line texts), so the editor content is authoritative.
+    // Markdown mode is lossless (the source is stored verbatim), so the editor content is authoritative.
     // WYSIWYG changes are only adopted lazily via getLosslessMarkdown's baseline check.
     if (editor.isMarkdownMode()) sourceText = baseGetMarkdown();
     syncTextarea();
   });
 
-  editor.on('changeMode', (...args: unknown[]) => {
-    const mode = args[0] as string;
+  editor.on('changeMode', (mode: unknown) => {
+    if (mode !== 'markdown' && mode !== 'wysiwyg') return;
     if (mode === 'wysiwyg') {
       mdSnapshot = sourceText;
-      wwBaseline = baseGetMarkdown();
+      wysiwygBaseline = baseGetMarkdown();
       syncTextarea();
       return;
     }
     // mode === 'markdown': the core just overwrote the markdown document with the WYSIWYG
-    // serialization (lossy) — even if nothing was edited — and that write already ran
+    // serialization (lossy), even if nothing was edited, and that write already ran
     // through the change handler above, clobbering sourceText.
     const serialized = baseGetMarkdown();
-    if (serialized === wwBaseline) {
+    if (serialized === wysiwygBaseline) {
       // No effective Visual edit: restore the pristine source. Deferred, because the core
       // still restores focus/selection (with positions mapped against the serialized doc)
       // after emitting `changeMode`; replacing the document synchronously would race that.
@@ -110,11 +110,11 @@ export function installLosslessMarkdownTracker(editor: LosslessEditor, textarea:
   if (textarea.value) {
     applyMarkdown(textarea.value);
   } else if (!editor.isMarkdownMode()) {
-    wwBaseline = baseGetMarkdown();
+    wysiwygBaseline = baseGetMarkdown();
   }
 
-  // Every consumer — submit handlers reading getMarkdown(), external code replacing the
-  // content via setMarkdown() — now goes through the lossless layer.
+  // Every consumer (submit handlers reading getMarkdown(), external code replacing the
+  // content via setMarkdown()) now goes through the lossless layer.
   editor.getMarkdown = getLosslessMarkdown;
   editor.setMarkdown = applyMarkdown;
 }

--- a/web_src/js/features/toast-editor.ts
+++ b/web_src/js/features/toast-editor.ts
@@ -2,6 +2,7 @@
 import Editor from '@toast-ui/editor';
 import '@toast-ui/editor/dist/toastui-editor.css';
 import {createBase64WidgetRule, installBase64WidgetPatch} from './comp/base64ImageWidget.ts';
+import {installLosslessMarkdownTracker} from './comp/losslessMarkdown.ts';
 import {showErrorToast} from '../modules/toast.ts';
 import {ensureFilesWithinLimit, getMaxAttachmentSize, showFileTooLargeError} from './comp/editorFileLimit.ts';
 
@@ -76,13 +77,8 @@ export async function createToastEditor(
     usageStatistics,
     hideModeSwitch,
     toolbarItems,
-    events: {
-      change: () => {
-        const content = editorRef.current!.getMarkdown();
-        textarea.value = content;
-        textarea.dispatchEvent(new Event('change'));
-      },
-    },
+    // NOTE: no `events.change` here — the lossless tracker installed below owns the
+    // editor→textarea sync so the WYSIWYG serializer can't rewrite untouched source.
     hooks: {
       addImageBlobHook: (blob: Blob, callback: (url: string, text?: string) => void) => {
         const max = getMaxAttachmentSize();
@@ -193,10 +189,11 @@ export async function createToastEditor(
   // Override getMarkdown to strip internal $$widget placeholders
   installBase64WidgetPatch(editor);
 
-  // Set initial content
-  if (textarea.value) {
-    editor.setMarkdown(textarea.value);
-  }
+  // Load the initial content and keep the user's markdown source byte-identical unless
+  // they actually edit in the visual editor (issue #262). Overrides getMarkdown/setMarkdown
+  // on top of the widget patch, so submit handlers need no changes. Must come after
+  // installBase64WidgetPatch so comparisons see widget-stripped output.
+  installLosslessMarkdownTracker(editor, textarea);
 
   // Rename mode switch labels
   const switchEl = container.querySelector('.toastui-editor-mode-switch');

--- a/web_src/js/features/toast-editor.ts
+++ b/web_src/js/features/toast-editor.ts
@@ -77,7 +77,7 @@ export async function createToastEditor(
     usageStatistics,
     hideModeSwitch,
     toolbarItems,
-    // NOTE: no `events.change` here — the lossless tracker installed below owns the
+    // NOTE: no `events.change` here, the lossless tracker installed below owns the
     // editor→textarea sync so the WYSIWYG serializer can't rewrite untouched source.
     hooks: {
       addImageBlobHook: (blob: Blob, callback: (url: string, text?: string) => void) => {


### PR DESCRIPTION
Coses #262 
### Problem
Toast UI's WYSIWYG serializer normalizes/escapes the source, and the core overwrites the markdown document with that lossy output on every Visual → Source switch — even untouched.
The "links not rendered" symptom is just the stock (correct) renderer faithfully displaying already-escaped committed text.

### Solution
- web_src/js/features/comp/losslessMarkdown.ts (new): tracks the authoritative source alongside the editor; overrides getMarkdown/setMarkdown (same pattern as the base64 widget patch) so every submit path is lossless with zero call-site changes. Untouched documents round-trip byte-identical through any tab switching; Source-mode edits keep the rest verbatim; only a genuine Visual edit adopts the serialized form (unavoidable — the serializer isn't configurable).
- toast-editor.ts: −11/+8 — the lossy events.change sync and raw initial setMarkdown are replaced by the tracker. This also fixes a page-load bug where the textarea was silently overwritten with normalized text before any user action.
- One deviation from the approved plan, for robustness: pristine source is snapshotted at each WYSIWYG entry (mdSnapshot) instead of the one-deep prevSourceText stash — same semantics, immune to event-ordering subtleties.

Co-author Fable5; review chatgpt 5.6 sol