### PR TITLE
Standardize pnpm 10 toolchain and harden workspace configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,8 @@
   "features": {
     // installs nodejs into container
     "ghcr.io/devcontainers/features/node:1": {
-      "version": "latest"
+      "version": "latest",
+      "pnpmVersion": "none"
     },
     "ghcr.io/devcontainers/features/git-lfs:1.2.5": {},
     "ghcr.io/jsburckhardt/devcontainer-features/uv:1": {},
@@ -42,5 +43,11 @@
       "onAutoForward": "notify"
     }
   },
+  // pnpm bootstrap is age-gated with --min-release-age to match the 14-day
+  // minimumReleaseAge policy in pnpm-workspace.yaml (`npm install -g` does not
+  // read the repo .npmrc). Must satisfy package.json#engines.pnpm.
+  // Runs in onCreateCommand so it is included in prebuilt containers and is in
+  // place before `make deps` below.
+  "onCreateCommand": "npm install -g --min-release-age=14 \"pnpm@^10.26.0\"",
   "postCreateCommand": "make deps"
 }

--- a/.github/workflows/files-changed.yml
+++ b/.github/workflows/files-changed.yml
@@ -62,6 +62,7 @@ jobs:
               - "assets/emoji.json"
               - "package.json"
               - "pnpm-lock.yaml"
+              - "pnpm-workspace.yaml"
               - "Makefile"
               - ".eslintrc.cjs"
               - ".npmrc"
@@ -71,6 +72,7 @@ jobs:
               - ".markdownlint.yaml"
               - "package.json"
               - "pnpm-lock.yaml"
+              - "pnpm-workspace.yaml"
 
             actions:
               - ".github/workflows/*"
@@ -94,6 +96,7 @@ jobs:
               - "Makefile"
               - "package.json"
               - "pnpm-lock.yaml"
+              - "pnpm-workspace.yaml"
               - ".spectral.yaml"
 
             yaml:

--- a/.github/workflows/pull-compliance.yml
+++ b/.github/workflows/pull-compliance.yml
@@ -37,7 +37,7 @@ jobs:
       - run: uv python install 3.12
       - uses: pnpm/action-setup@v4
         with:
-          version: "^10.16.0"
+          version: "^10.26.0"
       - uses: actions/setup-node@v5
         with:
           node-version: 24
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
-          version: "^10.16.0"
+          version: "^10.26.0"
       - uses: actions/setup-node@v5
         with:
           node-version: 24
@@ -136,7 +136,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
-          version: "^10.16.0"
+          version: "^10.26.0"
       - uses: actions/setup-node@v5
         with:
           node-version: 24
@@ -186,7 +186,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
         with:
-          version: "^10.16.0"
+          version: "^10.26.0"
       - uses: actions/setup-node@v5
         with:
           node-version: 24

--- a/.github/workflows/pull-e2e-tests.yml
+++ b/.github/workflows/pull-e2e-tests.yml
@@ -23,7 +23,7 @@ jobs:
           check-latest: true
       - uses: pnpm/action-setup@v4
         with:
-          version: "^10.16.0"
+          version: "^10.26.0"
       - uses: actions/setup-node@v5
         with:
           node-version: 24.15.0

--- a/.github/workflows/pull-tests.yml
+++ b/.github/workflows/pull-tests.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: "^10.16.0"
+          version: "^10.26.0"
 
       - name: Setup Node.js
         uses: actions/setup-node@v5

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -22,7 +22,7 @@ jobs:
           check-latest: true
       - uses: pnpm/action-setup@v4
         with:
-          version: "^10.16.0"
+          version: "^10.26.0"
       - uses: actions/setup-node@v5
         with:
           node-version: 24

--- a/.github/workflows/release-tag-rc.yml
+++ b/.github/workflows/release-tag-rc.yml
@@ -23,7 +23,7 @@ jobs:
           check-latest: true
       - uses: pnpm/action-setup@v4
         with:
-          version: "^10.16.0"
+          version: "^10.26.0"
       - uses: actions/setup-node@v5
         with:
           node-version: 24

--- a/.github/workflows/release-tag-version.yml
+++ b/.github/workflows/release-tag-version.yml
@@ -27,7 +27,7 @@ jobs:
           check-latest: true
       - uses: pnpm/action-setup@v4
         with:
-          version: "^10.16.0"
+          version: "^10.26.0"
       - uses: actions/setup-node@v5
         with:
           node-version: 24

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ Forkana is a fork of Gitea (self-hosted git service) that's been repurposed to a
 
 - **Go**: 1.25.1+ (see https://go.dev/doc/manage-install)
 - **Node.js**: 22.6.0+
-- **pnpm**: 10.16.0+ (required for `minimumReleaseAge` dependency age gating)
+- **pnpm**: 10.26.0+ (required for `minimumReleaseAge` dependency age gating and the `allowBuilds` build-script policy)
 - **git-lfs**: Required for binary assets
 - **Make**: Build system
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,13 +17,13 @@ ARG CGO_EXTRA_CFLAGS
 # Build deps
 # pnpm bootstrap is age-gated with --min-release-age to match the 14-day
 # minimumReleaseAge policy in pnpm-workspace.yaml (repo .npmrc is not yet
-# copied at this point). pnpm >= 10.16.0 is required.
+# copied at this point). pnpm >= 10.26.0 is required.
 RUN apk --no-cache add \
     build-base \
     git \
     nodejs \
     npm \
-    && npm install -g --min-release-age=14 "pnpm@^10.16.0" \
+    && npm install -g --min-release-age=14 "pnpm@^10.26.0" \
     && rm -rf /var/cache/apk/*
 
 # Setup repo

--- a/Dockerfile.rootless
+++ b/Dockerfile.rootless
@@ -17,13 +17,13 @@ ARG CGO_EXTRA_CFLAGS
 #Build deps
 # pnpm bootstrap is age-gated with --min-release-age to match the 14-day
 # minimumReleaseAge policy in pnpm-workspace.yaml (repo .npmrc is not yet
-# copied at this point). pnpm >= 10.16.0 is required.
+# copied at this point). pnpm >= 10.26.0 is required.
 RUN apk --no-cache add \
     build-base \
     git \
     nodejs \
     npm \
-    && npm install -g --min-release-age=14 "pnpm@^10.16.0" \
+    && npm install -g --min-release-age=14 "pnpm@^10.26.0" \
     && rm -rf /var/cache/apk/*
 
 # Setup repo

--- a/Makefile
+++ b/Makefile
@@ -883,6 +883,18 @@ update-js: node-check | node_modules ## update js dependencies
 	rm -rf node_modules pnpm-lock.yaml
 	$(NODE_VARS) pnpm install
 	$(NODE_VARS) pnpm exec nolyfill install
+	@# nolyfill writes package.json#pnpm.overrides, which REPLACES (not merges with)
+	@# the overrides in pnpm-workspace.yaml, silently dropping any entry nolyfill
+	@# does not manage, such as the cosmiconfig pin.
+	@if grep -qE '^  "pnpm"[[:space:]]*:' package.json; then \
+		echo "nolyfill re-created package.json#pnpm.overrides."; \
+		echo "That field REPLACES the overrides in pnpm-workspace.yaml rather than merging with"; \
+		echo "them, so every override pnpm-workspace.yaml holds that nolyfill does not manage"; \
+		echo "(e.g. the cosmiconfig pin) is silently dropped. pnpm 11 ignores the field entirely."; \
+		echo "Move the entries into pnpm-workspace.yaml#overrides, delete package.json#pnpm,"; \
+		echo "then re-run 'pnpm install'."; \
+		exit 1; \
+	fi
 	$(NODE_VARS) pnpm install
 	@touch node_modules
 

--- a/docker/forkana/Dockerfile
+++ b/docker/forkana/Dockerfile
@@ -16,13 +16,13 @@ ARG CGO_EXTRA_CFLAGS
 # Build deps
 # pnpm bootstrap is age-gated with --min-release-age to match the 14-day
 # minimumReleaseAge policy in pnpm-workspace.yaml (repo .npmrc is not yet
-# copied at this point). pnpm >= 10.16.0 is required.
+# copied at this point). pnpm >= 10.26.0 is required.
 RUN apk --no-cache add \
     build-base \
     git \
     nodejs \
     npm \
-    && npm install -g --min-release-age=14 "pnpm@^10.16.0" \
+    && npm install -g --min-release-age=14 "pnpm@^10.26.0" \
     && rm -rf /var/cache/apk/*
 
 # Setup repo

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1755186698,
-        "narHash": "sha256-wNO3+Ks2jZJ4nTHMuks+cxAiVBGNuEBXsT29Bz6HASo=",
+        "lastModified": 1785571196,
+        "narHash": "sha256-KoTsyMQqnXQZq8deCEnu4QkyldkwH/bpMMhUcfMdGIw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fbcf476f790d8a217c3eab4e12033dc4a0f6d23c",
+        "rev": "148bab9c1c3c53136ecb44a6ea356a0ed5b39b06",
         "type": "github"
       },
       "original": {

--- a/package.json
+++ b/package.json
@@ -119,25 +119,5 @@
   },
   "browserslist": [
     "defaults"
-  ],
-  "pnpm": {
-    "overrides": {
-      "array-includes": "npm:@nolyfill/array-includes@^1",
-      "array.prototype.findlastindex": "npm:@nolyfill/array.prototype.findlastindex@^1",
-      "array.prototype.flat": "npm:@nolyfill/array.prototype.flat@^1",
-      "array.prototype.flatmap": "npm:@nolyfill/array.prototype.flatmap@^1",
-      "es-aggregate-error": "npm:@nolyfill/es-aggregate-error@^1",
-      "hasown": "npm:@nolyfill/hasown@^1",
-      "is-core-module": "npm:@nolyfill/is-core-module@^1",
-      "object.assign": "npm:@nolyfill/object.assign@^1",
-      "object.fromentries": "npm:@nolyfill/object.fromentries@^1",
-      "object.groupby": "npm:@nolyfill/object.groupby@^1",
-      "object.values": "npm:@nolyfill/object.values@^1",
-      "safe-buffer": "npm:@nolyfill/safe-buffer@^1",
-      "safe-regex-test": "npm:@nolyfill/safe-regex-test@^1",
-      "safer-buffer": "npm:@nolyfill/safer-buffer@^1",
-      "string.prototype.includes": "npm:@nolyfill/string.prototype.includes@^1",
-      "string.prototype.trimend": "npm:@nolyfill/string.prototype.trimend@^1"
-    }
-  }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "type": "module",
   "engines": {
     "node": ">= 22.6.0",
-    "pnpm": ">= 10.16.0"
+    "pnpm": "^10.26.0"
   },
   "dependencies": {
     "@citation-js/core": "0.7.18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ overrides:
   array.prototype.findlastindex: npm:@nolyfill/array.prototype.findlastindex@^1
   array.prototype.flat: npm:@nolyfill/array.prototype.flat@^1
   array.prototype.flatmap: npm:@nolyfill/array.prototype.flatmap@^1
+  cosmiconfig: ^9.0.1
   es-aggregate-error: npm:@nolyfill/es-aggregate-error@^1
   hasown: npm:@nolyfill/hasown@^1
   is-core-module: npm:@nolyfill/is-core-module@^1
@@ -2254,8 +2255,8 @@ packages:
   cose-base@2.2.0:
     resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
 
-  cosmiconfig@9.0.0:
-    resolution: {integrity: sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==}
+  cosmiconfig@9.0.2:
+    resolution: {integrity: sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==}
     engines: {node: '>=14'}
     peerDependencies:
       typescript: '>=4.9.5'
@@ -3072,16 +3073,18 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@11.0.3:
     resolution: {integrity: sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==}
     engines: {node: 20 || >=22}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-modules@2.0.0:
     resolution: {integrity: sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==}
@@ -6843,7 +6846,7 @@ snapshots:
     dependencies:
       layout-base: 2.0.1
 
-  cosmiconfig@9.0.0(typescript@5.9.2):
+  cosmiconfig@9.0.2(typescript@5.9.2):
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
@@ -8769,7 +8772,7 @@ snapshots:
 
   postcss-loader@8.2.0(postcss@8.5.6)(typescript@5.9.2)(webpack@5.101.3):
     dependencies:
-      cosmiconfig: 9.0.0(typescript@5.9.2)
+      cosmiconfig: 9.0.2(typescript@5.9.2)
       jiti: 2.5.1
       postcss: 8.5.6
       semver: 7.7.2
@@ -9215,7 +9218,7 @@ snapshots:
       '@dual-bundle/import-meta-resolve': 4.2.1
       balanced-match: 2.0.0
       colord: 2.9.3
-      cosmiconfig: 9.0.0(typescript@5.9.2)
+      cosmiconfig: 9.0.2(typescript@5.9.2)
       css-functions-list: 3.2.3
       css-tree: 3.1.0
       debug: 4.4.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,6 +12,9 @@ overrides:
   array.prototype.findlastindex: npm:@nolyfill/array.prototype.findlastindex@^1
   array.prototype.flat: npm:@nolyfill/array.prototype.flat@^1
   array.prototype.flatmap: npm:@nolyfill/array.prototype.flatmap@^1
+  # 9.0.0 races when transpiling stylelint.config.ts: concurrent lints share one
+  # temp file and delete each other's. 9.0.1 makes the temp filename unique.
+  cosmiconfig: ^9.0.1
   es-aggregate-error: npm:@nolyfill/es-aggregate-error@^1
   hasown: npm:@nolyfill/hasown@^1
   is-core-module: npm:@nolyfill/is-core-module@^1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,21 @@
 # 14 days expressed in minutes (14 * 24 * 60)
 minimumReleaseAge: 20160
 minimumReleaseAgeExclude: []
+
+overrides:
+  array-includes: npm:@nolyfill/array-includes@^1
+  array.prototype.findlastindex: npm:@nolyfill/array.prototype.findlastindex@^1
+  array.prototype.flat: npm:@nolyfill/array.prototype.flat@^1
+  array.prototype.flatmap: npm:@nolyfill/array.prototype.flatmap@^1
+  es-aggregate-error: npm:@nolyfill/es-aggregate-error@^1
+  hasown: npm:@nolyfill/hasown@^1
+  is-core-module: npm:@nolyfill/is-core-module@^1
+  object.assign: npm:@nolyfill/object.assign@^1
+  object.fromentries: npm:@nolyfill/object.fromentries@^1
+  object.groupby: npm:@nolyfill/object.groupby@^1
+  object.values: npm:@nolyfill/object.values@^1
+  safe-buffer: npm:@nolyfill/safe-buffer@^1
+  safe-regex-test: npm:@nolyfill/safe-regex-test@^1
+  safer-buffer: npm:@nolyfill/safer-buffer@^1
+  string.prototype.includes: npm:@nolyfill/string.prototype.includes@^1
+  string.prototype.trimend: npm:@nolyfill/string.prototype.trimend@^1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,8 @@
+allowBuilds:
+  '@scarf/scarf': false
+  core-js: false
+  esbuild: false
+  unrs-resolver: false
 # 14 days expressed in minutes (14 * 24 * 60)
 minimumReleaseAge: 20160
 minimumReleaseAgeExclude: []


### PR DESCRIPTION
- [x] Standardize pnpm on ^10.26.0 across dev, CI, Docker, and Nix.
- [x] Move overrides into pnpm-workspace.yaml.
- [x] Enforce build-script and package-age security policies.
- [x] Pin cosmiconfig to fix flaky CSS linting.
- [x] Prevent update-js from silently replacing overrides.
- [x] Trigger relevant CI jobs on workspace-config changes.
- [x] Keep pnpm 11 blocked pending a dedicated migration.

Fixes #289

### AI Disclosure

Co-authored with: Opus 5