### PR TITLE
deps: override seroval to ^1.5.3 for CVE-2026-59940

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,6 +136,8 @@
       "safe-buffer": "npm:@nolyfill/safe-buffer@^1",
       "safe-regex-test": "npm:@nolyfill/safe-regex-test@^1",
       "safer-buffer": "npm:@nolyfill/safer-buffer@^1",
+      "seroval": "^1.5.3",
+      "seroval-plugins": "^1.5.3",
       "string.prototype.includes": "npm:@nolyfill/string.prototype.includes@^1",
       "string.prototype.trimend": "npm:@nolyfill/string.prototype.trimend@^1"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,8 @@ overrides:
   safe-buffer: npm:@nolyfill/safe-buffer@^1
   safe-regex-test: npm:@nolyfill/safe-regex-test@^1
   safer-buffer: npm:@nolyfill/safer-buffer@^1
+  seroval: ^1.5.3
+  seroval-plugins: ^1.5.3
   string.prototype.includes: npm:@nolyfill/string.prototype.includes@^1
   string.prototype.trimend: npm:@nolyfill/string.prototype.trimend@^1
 
@@ -4269,14 +4271,14 @@ packages:
   serialize-javascript@6.0.2:
     resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
 
-  seroval-plugins@1.3.3:
-    resolution: {integrity: sha512-16OL3NnUBw8JG1jBLUoZJsLnQq0n5Ua6aHalhJK4fMQkz1lqR7Osz1sA30trBtd9VUDc2NgkuRCn8+/pBwqZ+w==}
+  seroval-plugins@1.5.5:
+    resolution: {integrity: sha512-+BDhqYM6CEn3x09v44dpa9p6974FuUB2dxk+Ctn04k0cO1Zt6QODTXfmEZK0eBaTe/fJBvP4NMGuNJ+R8T+QMg==}
     engines: {node: '>=10'}
     peerDependencies:
-      seroval: ^1.0
+      seroval: ^1.5.3
 
-  seroval@1.3.2:
-    resolution: {integrity: sha512-RbcPH1n5cfwKrru7v7+zrZvjLurgHhGyso3HTyGtRivGWgYjbOmGuivCQaORNELjNONoK35nj28EoWul9sb1zQ==}
+  seroval@1.5.5:
+    resolution: {integrity: sha512-bSjOuPcwPKLSJNhr9+bZxA20nQxVle5J5MNsYRVE6cIg7KpRLXGupymePavu0jrxlPiPsr4xGZSB8yUY2sH2sw==}
     engines: {node: '>=10'}
 
   shallow-clone@3.0.1:
@@ -9050,11 +9052,11 @@ snapshots:
     dependencies:
       randombytes: 2.1.0
 
-  seroval-plugins@1.3.3(seroval@1.3.2):
+  seroval-plugins@1.5.5(seroval@1.5.5):
     dependencies:
-      seroval: 1.3.2
+      seroval: 1.5.5
 
-  seroval@1.3.2: {}
+  seroval@1.5.5: {}
 
   shallow-clone@3.0.1:
     dependencies:
@@ -9087,8 +9089,8 @@ snapshots:
   solid-js@1.9.9:
     dependencies:
       csstype: 3.1.3
-      seroval: 1.3.2
-      seroval-plugins: 1.3.3(seroval@1.3.2)
+      seroval: 1.5.5
+      seroval-plugins: 1.5.5(seroval@1.5.5)
 
   sortablejs@1.15.6: {}
 


### PR DESCRIPTION
* pin seroval/seroval-plugins via pnpm.overrides, lifting the transitive asciinema-player > solid-js > seroval@1.3.2 to 1.5.5.
* vulnerable fromJSON() was unreachable: no first-party call sites, and solid-js imports only serializer APIs in its SSR-only entry, which this Go-served app never bundles.

Fixes [seroval: `seroval.fromJSON()` Promise resolver type confusion invokes attacker-controlled methods during deserialization](https://github.com/okTurtles/forkana/security/dependabot/158)

### AI Disclosure

Co-authored with: Opus 5