### PR TITLE
httplib: add Content-Disposition regression test

### DIFF
--- a/modules/httplib/serve_test.go
+++ b/modules/httplib/serve_test.go
@@ -109,6 +109,23 @@ func TestServeContentByReadSeeker(t *testing.T) {
 	})
 }
 
+func TestServeSetHeadersContentDisposition(t *testing.T) {
+	// a filename without an explicit disposition must default to "attachment", so that
+	// user-controlled content is never rendered inline by the browser
+	w := httptest.NewRecorder()
+	ServeSetHeaders(w, &ServeHeaderOptions{Filename: "foo.zip"})
+	assert.Equal(t, `attachment; filename="foo.zip"; filename*=UTF-8''foo.zip`, w.Header().Get("Content-Disposition"))
+	assert.Equal(t, "Content-Disposition", w.Header().Get("Access-Control-Expose-Headers"))
+
+	w = httptest.NewRecorder()
+	ServeSetHeaders(w, &ServeHeaderOptions{Filename: "foo.zip", Disposition: "inline"})
+	assert.Equal(t, `inline; filename="foo.zip"; filename*=UTF-8''foo.zip`, w.Header().Get("Content-Disposition"))
+
+	w = httptest.NewRecorder()
+	ServeSetHeaders(w, &ServeHeaderOptions{})
+	assert.Empty(t, w.Header().Get("Content-Disposition"))
+}
+
 func TestServeSetHeaderContentRelated(t *testing.T) {
 	cases := []struct {
 		contentType string


### PR DESCRIPTION
- [x] added TestServeSetHeadersContentDisposition covering attachment default, explicit inline, and empty-filename cases

Reviewed [Gitea PR #37552 changes](https://github.com/go-gitea/gitea/pull/37552/changes): `ServeSetHeaders` already defaults to attachment when Filename is set, so no need to fix. Just added tests.

Closes #213

### AI Disclosure

Co-authored with: Opus 5