### PR TITLE
session: store session management in the database

### DIFF
--- a/docker/forkana/dev.yml
+++ b/docker/forkana/dev.yml
@@ -75,6 +75,13 @@ services:
       GITEA__database__PASSWD: ${POSTGRES_PASSWORD}
       GITEA__database__SSL_MODE: disable
 
+      # Session
+      # Required, not just a default: docker-setup.sh only writes app.ini when
+      # it is absent, and /etc/gitea is a persistent volume, so deployments
+      # created before the db switch keep PROVIDER = file without this override.
+      GITEA__session__PROVIDER: db
+      GITEA__session__SESSION_LIFE_TIME: "604800"
+
       # Service
       GITEA__service__DISABLE_REGISTRATION: "true"
 

--- a/docker/forkana/etc/templates/app.ini
+++ b/docker/forkana/etc/templates/app.ini
@@ -48,8 +48,10 @@ SSL_MODE = disable
 LOG_SQL  = false
 
 [session]
-PROVIDER = file
-PROVIDER_CONFIG = $GITEA_WORK_DIR/data/sessions
+; Sessions live in the database so they survive container recreation without
+; depending on the bind-mounted data directory or its ownership.
+PROVIDER = db
+SESSION_LIFE_TIME = 604800
 
 [picture]
 AVATAR_UPLOAD_PATH = $GITEA_WORK_DIR/data/avatars


### PR DESCRIPTION
With this PR sessions will be stored with the `db` provider so they persist in PostgreSQL together with the user data and they'll persist on deployments and container recreation.

The deployments before this change are storing sessions as files under `~/forkana/data/data/sessions`. The first deploy that applies `GITEA__session__PROVIDER: db` starts reading from the `session` table instead, and the old session files won't be migrated. This means that the current active users will be signed out and must log in again. After this and in the following deployments they won't be logged out again. As for the users who selected "remember me", they stay signed in as long as `FORKANA_SECRET_KEY` in `.env` is unchanged.

#### Steps for the next deployment:
(/cc @taoeffect)

1. Confirm the value is the same one already in use (rotating it invalidates all "remember me" cookies):

```bash
grep FORKANA_SECRET_KEY ~/forkana/config/.env > /dev/null && echo "key present"
```

2. Recreate the container

```bash
./docker/forkana/deploy.sh "${COMMIT_SHA}"
```
Environment-to-ini should apply `GITEA__session__PROVIDER` / `GITEA__session__SESSION_LIFE_TIME` from `dev.yml` to the persisted `/etc/gitea/app.ini` (the script waits on `/api/healthz` and rolls back automatically on failure).

3. Verify config aplied

```bash
docker exec forkana grep -A3 '^\[session\]' /etc/gitea/app.ini
```
Expect `PROVIDER = db` and `SESSION_LIFE_TIME = 604800`, with no `PROVIDER_CONFIG`.

5. Verify rows are being written (sign in through the UI first, then):

```bash
docker exec forkana-postgres psql -U forkana -d forkana \
    -c "SELECT count(*) FROM session;"
```
Count must be >= 1 and grow with each new login.

Confirm persistence:

```bash
docker compose -p forkana --project-directory docker/forkana \
    -f docker/forkana/dev.yml up -d --force-recreate forkana
```

Reload the browser - the session must survive without re-authenticating.

6. Cleanup:

```bash
rm -rf ~/forkana/data/data/sessions
```

----

Fixes #286

### AI Disclosure

Co-authored with: Opus 5